### PR TITLE
Pygrb o2 dev

### DIFF
--- a/bin/pylal_cbc_cohptf_efficiency
+++ b/bin/pylal_cbc_cohptf_efficiency
@@ -195,19 +195,19 @@ def parse_command_line():
                      help="The standard deviation to use when calculating the "\
                           "V1 calibration amplitude error.")
   calopts.add_option("-p", "--h1-dc-cal-error", action="store",\
-                     type="float", default=0,
+                     type="float", default=1.0,
                      help="The scaling factor to use when calculating the H1 "\
                            "calibration amplitude error.")
   calopts.add_option("-P", "--h2-dc-cal-error", action="store",\
-                     type="float", default=0,
+                     type="float", default=1.0,
                      help="The scaling factor to use when calculating the H2 "\
                            "calibration amplitude error.")
   calopts.add_option( "-r", "--l1-dc-cal-error", action="store",\
-                     type="float", default=0,
+                     type="float", default=1.0,
                      help="The scaling factor to use when calculating the L1 "\
                            "calibration amplitude error.")
   calopts.add_option("-R", "--v1-dc-cal-error", action="store",\
-                     type="float", default=0,
+                     type="float", default=1.0,
                      help="The scaling factor to use when calculating the V1 "\
                            "calibration amplitude error.")
 

--- a/bin/pylal_cbc_cohptf_efficiency
+++ b/bin/pylal_cbc_cohptf_efficiency
@@ -582,11 +582,12 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
         if val > bestNR:
           numTrialsLouder += 1
     FAP = numTrialsLouder/totalTrials
+    pval = '< %.3g' % (1./totalTrials) if FAP==0 else '%.3g' % FAP
 
     # Get null SNR of trigger
     nullsnr = trig.get_null_snr()
 
-    d = [ '%s-%s' % tuple(trigBin), chunkNum, trigSlideID, '%.2f' % FAP,\
+    d = [ '%s-%s' % tuple(trigBin), chunkNum, trigSlideID, pval,\
           '%.4f' % trig.get_end(),\
           '%.2f' % trig.mass1, '%.2f' % trig.mass2, '%.2f' % trig.mchirp,\
           '%.2f' % (np.degrees(trig.ra)), '%.2f'% (np.degrees(trig.dec)),\
@@ -745,14 +746,15 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
           numTrialsLouder += sum(timeBinVetoMaxBestNR[slideID][i] > \
                                  loudOnBestNR[bin[0]])
         FAP = numTrialsLouder/totalTrials
+        pval = '< %.3g' % (1./totalTrials) if FAP==0 else '%.3g' % FAP
         loudOnFAP[bin[0]] = FAP
-        d = ['%s-%s' % tuple(bin), FAP, trig.get_end(),\
+        d = ['%s-%s' % tuple(bin), pval, trig.get_end(),\
              trig.mass1, trig.mass2, trig.mchirp,\
              np.degrees(trig.ra), np.degrees(trig.dec),\
              trig.snr, trig.chisq, trig.bank_chisq,\
              trig.cont_chisq, nullsnr] + \
             [trig.get_sngl_snr(ifo) for ifo in ifos] + [loudOnBestNR[bin[0]]]
-        file2.write('%s\n' % FAP)
+        file2.write('%s\n' % pval.replace('<', '&lt'))
         td.append(d)
 
       else:

--- a/bin/pylal_cbc_cohptf_trig_combiner
+++ b/bin/pylal_cbc_cohptf_trig_combiner
@@ -76,7 +76,7 @@ coh_PTF_trig_combiner is designed to coalesce the triggers made from each elemen
                                         "(will be appended to output user tag")
 
   parser.add_argument("-T", "--num-trials", type=int, default=6,
-                      help="The number of off source trials")
+                      help="The number of off source trials, default: %(default)d")
 
   parser.add_argument("-p", "--trig-start-time", type=int, required=True,
                       help="The start time of the analysis segment")
@@ -86,8 +86,8 @@ coh_PTF_trig_combiner is designed to coalesce the triggers made from each elemen
                            "segment files")
 
   parser.add_argument("-o", "--output-dir", action="store", type=str,
-                      default=os.getcwd(), help="output directory, "
-                                                "default: %s" % os.getcwd())
+                      default=os.getcwd(),
+                      help="output directory, default: current working dir")
 
   parser.add_argument("-t", "--long-slides", action="store_true",
                       help="Are these triggers from long time slides?")

--- a/bin/pylal_cbc_cohptf_trig_combiner
+++ b/bin/pylal_cbc_cohptf_trig_combiner
@@ -75,12 +75,10 @@ coh_PTF_trig_combiner is designed to coalesce the triggers made from each elemen
                       default=None, help="GRB name, such as 090802 "+
                                         "(will be appended to output user tag")
 
-  parser.add_argument("-T", "--num-trials", action="store", type=int,
-                      default=6,
-                      help="The number of off source trials, default: %default")
+  parser.add_argument("-T", "--num-trials", type=int, default=6,
+                      help="The number of off source trials")
 
-  parser.add_argument("-p", "--trig-start-time", action="store", type=int,
-                      required=True,
+  parser.add_argument("-p", "--trig-start-time", type=int, required=True,
                       help="The start time of the analysis segment")
 
   parser.add_argument("-a", "--segment-dir", action="store", type=str,
@@ -89,14 +87,14 @@ coh_PTF_trig_combiner is designed to coalesce the triggers made from each elemen
 
   parser.add_argument("-o", "--output-dir", action="store", type=str,
                       default=os.getcwd(), help="output directory, "
-                                                "default: %default")
+                                                "default: %s" % os.getcwd())
 
-  parser.add_argument("-t", "--slide-cache", action="store",default=None,
-                      help="Read slide triggers from this cache")
+  parser.add_argument("-t", "--long-slides", action="store_true",
+                      help="Are these triggers from long time slides?")
 
   parser.add_argument("-b", "--verbose", action="store_true", default=False,
                       help="verbose output with microsecond timer, "
-                           "default: %default")
+                           "default: False")
 
   parser.add_argument("-f", "--input-files", nargs="*", action="store",
                       required=True, metavar="TRIGGER FILE",
@@ -126,7 +124,7 @@ coh_PTF_trig_combiner is designed to coalesce the triggers made from each elemen
 # =============================================================================
 
 def main(trigFiles, ifoTag, userTag, segdir, outdir, grbTag=None, jobTag=None,
-         numTrials=6, timeSlides=None, slideTag=None, trigStart=None,
+         numTrials=6, timeSlides=False, slideTag=None, trigStart=None,
          shortSlides=False, verbose=False):
   
   if verbose: sys.stdout.write("Getting segments...\n")
@@ -165,17 +163,17 @@ def main(trigFiles, ifoTag, userTag, segdir, outdir, grbTag=None, jobTag=None,
   # get trigger files 
   if verbose: sys.stdout.write("\nFinding files...\n")
 
-  if timeSlides:
-    slideCache = lal.Cache.fromfile(open(timeSlides, 'r'))
-    slideCache = slideCache.sieve(ifos=ifoTag, description=userTag)
-    if slideTag:
-      slideCache = slideCache.sieve(description=slideTag)
-    if len(slideCache)<1:
-      sys.stderr.write("No files found at %d.\n" % elapsed_time())
-      sys.exit(1)
-    else:
-      sys.stdout.write("%d files found at %d.\n"\
-                       % (len(slideCache), elapsed_time()))
+  #if timeSlides:
+  #  slideCache = lal.Cache.fromfile(open(timeSlides, 'r'))
+  #  slideCache = slideCache.sieve(ifos=ifoTag, description=userTag)
+  #  if slideTag:
+  #    slideCache = slideCache.sieve(description=slideTag)
+  #  if len(slideCache)<1:
+  #    sys.stderr.write("No files found at %d.\n" % elapsed_time())
+  #    sys.exit(1)
+  #  else:
+  #    sys.stdout.write("%d files found at %d.\n"\
+  #                     % (len(slideCache), elapsed_time()))
 
   # set columns
   ifoAtt = { 'G1':'g', 'H1':'h1', 'H2':'h2', 'L1':'l', 'V1':'v', 'T1':'t' }
@@ -232,7 +230,7 @@ def main(trigFiles, ifoTag, userTag, segdir, outdir, grbTag=None, jobTag=None,
             lsctables.SegmentTable.tableName)
     timeSlideSegmentMap = table.get_table(timeSlideDoc,
             lsctables.TimeSlideSegmentMapTable.tableName)
-  elif shortSlides:
+  elif shortSlides and not timeSlides:
     zeroLagTrigs = {}
     zeroLagTrigs['ALL_TIMES'] = copy.deepcopy(trigs['ALL_TIMES'])
     
@@ -246,16 +244,16 @@ def main(trigFiles, ifoTag, userTag, segdir, outdir, grbTag=None, jobTag=None,
                if all(v == 0 for v in slide.values())]
     zeroLagTrigs['ALL_TIMES'].extend([trig for trig in trigs['ALL_TIMES'] \
                                       if int(trig.time_slide_id) in zeroIDs])
+  elif timeSlides:
+    tempTrigs, slideDictList, segmentDict, timeSlideTable, segmentTable, \
+            timeSlideSegmentMap = \
+            MultiInspiralUtils.ReadMultiInspiralTimeSlidesFromFiles(\
+            trigFiles, generate_output_tables=True)
+    trigs['ALL_TIMES'].extend(tempTrigs)
   else:
     trigs['ALL_TIMES'] = lsctables.New(lsctables.MultiInspiralTable,\
                                columns=lsctables.MultiInspiralTable.loadcolumns)
-    if trigFiles:
-      inpFiles = [e for e in trigFiles]
-    else:
-      inpFiles = []
-    inpFiles.extend([e for e in slideCache])
-    if not trigFiles:
-      cache = slideCache
+    inpFiles = [e for e in trigFiles]
     tempTrigs,slideDictList,segmentDict,timeSlideTable,\
         segmentTable,timeSlideSegmentMap = \
             MultiInspiralUtils.ReadMultiInspiralTimeSlidesFromFiles(inpFiles,\
@@ -312,7 +310,7 @@ def main(trigFiles, ifoTag, userTag, segdir, outdir, grbTag=None, jobTag=None,
 
   if verbose: sys.stdout.write("\nSeparating triggers by end time...\n")
 
-  if shortSlides or timeSlides:
+  if shortSlides and not timeSlides:
     zeroLagTrigs['ONSOURCE'] = lsctables.New(lsctables.MultiInspiralTable,\
                                columns=lsctables.MultiInspiralTable.loadcolumns)
     zeroLagTrigs['OFFSOURCE'] = copy.deepcopy(zeroLagTrigs['ONSOURCE'])
@@ -335,10 +333,8 @@ def main(trigFiles, ifoTag, userTag, segdir, outdir, grbTag=None, jobTag=None,
   if shortSlides or timeSlides:
     for trig in trigs['ALL_TIMES']:
       slideID = int(trig.time_slide_id)
-      in_buffer = []
-      for ifo in ifos:
-        offset = slideDictList[slideID][ifo]
-        in_buffer.append(trig.get_end()+offset in segs['buffer'])
+      in_buffer = [trig.get_end() + slideDictList[slideID][ifo]
+                   in segs['buffer'] for ifo in ifos]
       if not any(in_buffer):
           trigs['OFFSOURCE'].append(trig)
   else:
@@ -388,6 +384,10 @@ def main(trigFiles, ifoTag, userTag, segdir, outdir, grbTag=None, jobTag=None,
     tsUserTag = '%s_TIMESLIDES' %(userTag)
     if grbTag:
       tsUserTag = '%s_GRB%s' % (tsUserTag, grbTag)
+    if slideTag:
+      tsUserTag = '%s_%s' % (tsUserTag, slideTag)
+    if jobTag:
+      tsUserTag = '%s_%s' % (tsUserTag, jobTag)
   if grbTag:
     userTag = '%s_GRB%s' % (userTag, grbTag)
   if jobTag:
@@ -428,12 +428,8 @@ def main(trigFiles, ifoTag, userTag, segdir, outdir, grbTag=None, jobTag=None,
 
   else:
     for trigTime in trigs.keys():
-      if slideTag:
-        fullTag = '%s-%s_%s' %(ifoTag, tsUserTag, slideTag)
-      else:
-        fullTag = '%s-%s' %(ifoTag, tsUserTag)
-      xmlName = '%s/%s_%s-%d-%d.xml.gz'\
-                % (outdir, fullTag, trigTime, start, end-start)
+      xmlName = '%s/%s-%s_%s-%d-%d.xml.gz'\
+                % (outdir, ifoTag, tsUserTag, trigTime, start, end-start)
       xmldoc.childNodes[-1].appendChild(trigs[trigTime])
       utils.write_filename(xmldoc, xmlName, gz = xmlName.endswith('gz'))
       xmldoc.childNodes[-1].removeChild(trigs[trigTime])
@@ -453,7 +449,7 @@ if __name__=='__main__':
   trigFiles   = args.input_files
   GRBname     = args.grb_name
   numTrials   = args.num_trials
-  timeSlides  = args.slide_cache
+  timeSlides  = args.long_slides
   slideTag    = args.slide_tag
   trigStart   = args.trig_start_time
   shortSlides = args.short_slides

--- a/bin/pylal_cbc_cohptf_trig_combiner
+++ b/bin/pylal_cbc_cohptf_trig_combiner
@@ -163,18 +163,6 @@ def main(trigFiles, ifoTag, userTag, segdir, outdir, grbTag=None, jobTag=None,
   # get trigger files 
   if verbose: sys.stdout.write("\nFinding files...\n")
 
-  #if timeSlides:
-  #  slideCache = lal.Cache.fromfile(open(timeSlides, 'r'))
-  #  slideCache = slideCache.sieve(ifos=ifoTag, description=userTag)
-  #  if slideTag:
-  #    slideCache = slideCache.sieve(description=slideTag)
-  #  if len(slideCache)<1:
-  #    sys.stderr.write("No files found at %d.\n" % elapsed_time())
-  #    sys.exit(1)
-  #  else:
-  #    sys.stdout.write("%d files found at %d.\n"\
-  #                     % (len(slideCache), elapsed_time()))
-
   # set columns
   ifoAtt = { 'G1':'g', 'H1':'h1', 'H2':'h2', 'L1':'l', 'V1':'v', 'T1':'t' }
   # set up columns

--- a/pylal/legacy_ihope.py
+++ b/pylal/legacy_ihope.py
@@ -673,6 +673,7 @@ class PyGRBMakeSummaryPage(LegacyAnalysisExecutable):
             tags = []
         super(PyGRBMakeSummaryPage, self).__init__(cp, name, universe, ifo=ifo,
               out_dir=out_dir, tags=tags)
+        self.cp = cp
         self.ifos = ifo
         self.num_threads = 1
 
@@ -688,6 +689,11 @@ class PyGRBMakeSummaryPage(LegacyAnalysisExecutable):
         node.add_opt('--ra', self.cp.get('workflow', 'ra'))
         node.add_opt('--dec', self.cp.get('workflow', 'dec'))
         node.add_opt('--ifo-tag', self.ifos)
+
+        if self.cp.has_option_tag('inspiral', 'do-short-slides',
+                                  'coherent_no_injections') \
+                or self.cp.has_option('workflow', 'do-long-slides'):
+            node.add_opt('--time-slides')
 
         if tuning_tags is not None:
             node.add_opt('--tuning-injections', ','.join(tuning_tags))

--- a/pylal/legacy_ihope.py
+++ b/pylal/legacy_ihope.py
@@ -31,7 +31,7 @@ https://ldas-jobs.ligo.caltech.edu/~cbc/docs/pycbc/ahope.html
 
 import os
 import urlparse
-from pycbc_glue import segments
+from glue import segments
 from pycbc.workflow.core import Executable, File, FileList, Node
 
 

--- a/pylal/legacy_ihope.py
+++ b/pylal/legacy_ihope.py
@@ -679,7 +679,7 @@ class PyGRBMakeSummaryPage(LegacyAnalysisExecutable):
 
     def create_node(self, parent=None, c_file=None, open_box=False,
                     seg_plot=None, tuning_tags=None, exclusion_tags=None,
-                    html_dir=None, tags=None):
+                    html_dir=None, time_slides=None, tags=None):
         if tags is None:
             tags = []
         node = Node(self)
@@ -690,9 +690,7 @@ class PyGRBMakeSummaryPage(LegacyAnalysisExecutable):
         node.add_opt('--dec', self.cp.get('workflow', 'dec'))
         node.add_opt('--ifo-tag', self.ifos)
 
-        if self.cp.has_option_tag('inspiral', 'do-short-slides',
-                                  'coherent_no_injections') \
-                or self.cp.has_option('workflow', 'do-long-slides'):
+        if time_slides is not None:
             node.add_opt('--time-slides')
 
         if tuning_tags is not None:

--- a/pylal/pygrb_cohptf_pp.py
+++ b/pylal/pygrb_cohptf_pp.py
@@ -223,10 +223,10 @@ def setup_coh_PTF_injections_pp(wf, inj_trigger_files, inj_files,
 
 def setup_coh_PTF_plotting_jobs(workflow, unclust_file, clust_file,
         sbv_plotter_jobs, efficiency_jobs, inj_efficiency_jobs,
-        trig_cluster_node, off_node, offsource_clustered, injfinder_nodes,
-        injcombiner_nodes, dep_nodes, injcombiner_outs,
-        inj_sbv_plotter_parent_nodes, inj_tags, injcombiner_out_tags, pp_nodes,
-        output_dir, segment_dir, ifos, out_tag, do_injs=False, tags=None):
+        off_node, dep_node, offsource_clustered, injfinder_nodes,
+        injcombiner_nodes, injcombiner_outs, inj_sbv_plotter_parent_nodes,
+        inj_tags, injcombiner_out_tags, pp_nodes, output_dir, segment_dir,
+        ifos, out_tag, do_injs=False, tags=None):
     """
     Creates signal-based veto and efficiency jobs
     """
@@ -238,8 +238,8 @@ def setup_coh_PTF_plotting_jobs(workflow, unclust_file, clust_file,
                                                         tags=sbv_out_tags)
         pp_nodes.append(sbv_plotter_node)
         workflow.add_node(sbv_plotter_node)
-        for dep_node in dep_nodes:
-            dep = dax.Dependency(parent=dep_node._dax_node,
+        for n in set((off_node, dep_node)):
+            dep = dax.Dependency(parent=n._dax_node,
                                  child=sbv_plotter_node._dax_node)
             workflow._adag.addDependency(dep)
 
@@ -283,12 +283,11 @@ def setup_coh_PTF_plotting_jobs(workflow, unclust_file, clust_file,
                 offsource_clustered, segment_dir, tags=[out_tag])
         pp_nodes.append(efficiency_node)
         workflow.add_node(efficiency_node)
-        dep = dax.Dependency(parent=off_node._dax_node,
+        dep = dax.Dependency(parent=dep_node._dax_node,
                              child=efficiency_node._dax_node)
         workflow._adag.addDependency(dep)
 
         if do_injs:
-            logging.info(clust_file.name)
             for tag in injcombiner_out_tags:
                 if "_FILTERED_" in tag:
                     inj_set_tag = [t for t in inj_tags if \
@@ -307,7 +306,7 @@ def setup_coh_PTF_plotting_jobs(workflow, unclust_file, clust_file,
                                                        inj_set_tag])
                 pp_nodes.append(inj_efficiency_node)
                 workflow.add_node(inj_efficiency_node)
-                dep = dax.Dependency(parent=off_node._dax_node,
+                dep = dax.Dependency(parent=dep_node._dax_node,
                                      child=inj_efficiency_node._dax_node)
                 workflow._adag.addDependency(dep)
                 for injcombiner_node in injcombiner_nodes:
@@ -420,345 +419,13 @@ def setup_postproc_coh_PTF_offline_workflow(workflow, trig_files, trig_cache,
         inj_efficiency_jobs = efficiency_class(cp, "inj_efficiency", ifo=ifos,
                                                out_dir=output_dir, tags=tags)
 
-    # Set up trig_combiner job
+    # Set up main trig_combiner class and tags
     trig_combiner_out_tags = ["OFFSOURCE", "ONSOURCE", "ALL_TIMES"]
     if all("COHERENT_NO_INJECTIONS" in t.name for t in trig_files) and \
             cp.has_option_tag("inspiral", "do-short-slides",
                               "coherent_no_injections"):
         trig_combiner_out_tags.extend(["ZEROLAG_OFF", "ZEROLAG_ALL"])
     
-    trig_combiner_jobs = trig_combiner_class(cp, "trig_combiner", ifo=ifos, 
-                                             out_dir=output_dir, tags=tags)
-    trig_combiner_node, trig_combiner_outs = trig_combiner_jobs.create_node(\
-            trig_files, segment_dir, workflow.analysis_time,
-            out_tags=trig_combiner_out_tags, tags=tags)
-    pp_nodes.append(trig_combiner_node)
-    workflow.add_node(trig_combiner_node)
-    pp_outs.extend(trig_combiner_outs)
-
-    # Initialise trig_cluster class
-    trig_cluster_outs = FileList([])
-    trig_cluster_jobs = trig_cluster_class(cp, "trig_cluster", ifo=ifos,
-                                           out_dir=output_dir, tags=tags)
-
-    # Set up trig_cluster jobs
-    trig_cluster_nodes = []
-    for out_tag in trig_combiner_out_tags:
-        unclust_file = [f for f in trig_combiner_outs \
-                        if out_tag in f.tag_str][0]
-        trig_cluster_node, curr_outs = trig_cluster_jobs.create_node(\
-                unclust_file)
-        trig_cluster_outs.extend(curr_outs)
-        clust_file = curr_outs[0]
-        trig_cluster_nodes.append(trig_cluster_node)
-        pp_nodes.append(trig_cluster_node)
-        workflow.add_node(trig_cluster_node)
-        dep = dax.Dependency(parent=trig_combiner_node._dax_node,
-                             child=trig_cluster_node._dax_node)
-        workflow._adag.addDependency(dep)
-        if ts_trig_files is None:
-            off_node = trig_combiner_all_node
-            offsource_clustered = clust_file
-
-    # Are we doing time slides?
-    if ts_trig_files is not None:
-        trig_combiner_ts_nodes = []
-        trig_cluster_ts_nodes = []
-        trig_cluster_all_times_nodes = []
-        ts_all_times_outs = FileList([out for out in trig_cluster_outs
-                                      if "ALL_TIMES" in out.tag_str])
-        trig_combiner_ts_out_tags = ["ALL_TIMES", "OFFSOURCE"]
-        ts_tags = list(set([[ts_tag for ts_tag in ts_trig_file.tags
-                             if "SLIDE" in ts_tag][0]
-                            for ts_trig_file in ts_trig_files]))
-        for ts_tag in ts_tags:
-            # Do one slide at a time
-            ts_trigs = FileList([ts_trig_file for ts_trig_file in ts_trig_files
-                                 if ts_tag in ts_trig_file.tags])
-            trig_combiner_ts_node, trig_combiner_ts_outs = \
-                    trig_combiner_jobs.create_node(ts_trigs, segment_dir,
-                            workflow.analysis_time, slide_tag=ts_tag,
-                            out_tags=trig_combiner_ts_out_tags, tags=tags)
-            trig_combiner_ts_nodes.append(trig_combiner_ts_node)
-            pp_nodes.append(trig_combiner_ts_node)
-            workflow.add_node(trig_combiner_ts_node)
-            pp_outs.extend(trig_combiner_ts_outs)
-
-            # Set up trig combiner jobs for each timeslide
-            for ts_out_tag in trig_combiner_ts_out_tags:
-                unclust_file = [f for f in trig_combiner_ts_outs \
-                                if ts_out_tag in f.tag_str][0]
-                trig_cluster_node, curr_outs = trig_cluster_jobs.create_node(\
-                        unclust_file)
-                trig_cluster_outs.extend(curr_outs)
-                clust_file = curr_outs[0]
-                trig_cluster_ts_nodes.append(trig_cluster_node)
-                pp_nodes.append(trig_cluster_node)
-                workflow.add_node(trig_cluster_node)
-                dep = dax.Dependency(parent=trig_combiner_ts_node._dax_node,
-                                     child=trig_cluster_node._dax_node)
-                workflow._adag.addDependency(dep)        
-                if ts_out_tag == "ALL_TIMES":
-                    trig_cluster_all_times_nodes.append(trig_cluster_node)
-                    ts_all_times_outs.extend(FileList([clust_file]))
-
-        # Combine all timeslides
-        trig_combiner_all_node, trig_combiner_all_outs = \
-                trig_combiner_jobs.create_node(ts_all_times_outs, segment_dir,
-                            workflow.analysis_time, slide_tag="ALL_SLIDES",
-                            out_tags=trig_combiner_ts_out_tags, tags=tags)
-        pp_nodes.append(trig_combiner_all_node)
-        workflow.add_node(trig_combiner_all_node)
-        for trig_cluster_ts_node in trig_cluster_all_times_nodes:
-            dep = dax.Dependency(parent=trig_cluster_ts_node._dax_node,
-                                 child=trig_combiner_all_node._dax_node)
-            workflow._adag.addDependency(dep)        
-
-        for out_tag in trig_combiner_ts_out_tags:
-            trig_cluster_outs = FileList([f for f in trig_cluster_outs
-                                          if out_tag not in f.tag_str])
-        trig_cluster_outs.extend(trig_combiner_all_outs)
-        off_node = trig_combiner_all_node
-        offsource_clustered = [f for f in trig_cluster_outs
-                               if "OFFSOURCE" in f.tag_str
-                               and "ZERO_LAG" not in f.tag_str][0]
-
-    # Initialise sbv_plotter class
-    sbv_plotter_outs = FileList([])
-    sbv_plotter_jobs = sbv_plotter_class(cp, "sbv_plotter", ifo=ifos,
-                                         out_dir=output_dir, tags=tags)
-
-    # Initialise efficiency class
-    efficiency_outs = FileList([])
-    efficiency_jobs = efficiency_class(cp, "efficiency", ifo=ifos,
-                                       out_dir=output_dir, tags=tags)
-
-    # Add sbv_plotter and efficiency jobs
-    for out_tag in trig_combiner_out_tags:
-        clust_file = [f for f in trig_cluster_outs \
-                      if out_tag in f.tag_str][0]
-        #trig_cluster_node, curr_outs = trig_cluster_jobs.create_node(\
-        #        unclust_file)
-        #trig_cluster_outs.extend(curr_outs)
-        #clust_file = curr_outs[0]
-        #pp_nodes.append(trig_cluster_node)
-        #workflow.add_node(trig_cluster_node)
-        #dep = dax.Dependency(parent=trig_combiner_node._dax_node,
-        #                     child=trig_cluster_node._dax_node)
-        #workflow._adag.addDependency(dep)
-
-        if ts_trig_files is not None:
-            final_trig_nodes = [trig_combiner_all_node]
-        else:
-            final_trig_nodes = [f for f in trig_cluster_nodes
-                                if out_tag in f.tag]
-        workflow, pp_nodes = setup_coh_PTF_plotting_jobs(workflow, 
-                unclust_file, clust_file, sbv_plotter_jobs, efficiency_jobs,
-                inj_efficiency_jobs, trig_cluster_node, off_node,
-                offsource_clustered, injfinder_nodes, injcombiner_nodes,
-                final_trig_nodes, injcombiner_outs,
-                inj_sbv_plotter_parent_nodes, inj_tags, injcombiner_out_tags,
-                pp_nodes, output_dir, segment_dir, ifos, out_tag,
-                do_injs=do_injections, tags=tags)
-
-    # Add further trig_cluster jobs for trials
-    trial = 1
-
-    while trial <= num_trials:
-        trial_tag = "OFFTRIAL_%d" % trial
-        unclust_file = [f for f in trig_combiner_outs \
-                        if trial_tag in f.tag_str][0]
-        trig_cluster_node, clust_outs = trig_cluster_jobs.create_node(\
-                unclust_file)
-        clust_file = clust_outs[0]
-        trig_cluster_outs.extend(clust_outs)
-        pp_nodes.append(trig_cluster_node)
-        workflow.add_node(trig_cluster_node)
-        dep = dax.Dependency(parent=trig_combiner_node._dax_node,
-                             child=trig_cluster_node._dax_node)
-        workflow._adag.addDependency(dep)
-
-        # Add efficiency job
-        efficiency_node = efficiency_jobs.create_node(clust_file,
-                offsource_clustered, segment_dir, tags=[trial_tag])
-        pp_nodes.append(efficiency_node)
-        workflow.add_node(efficiency_node)
-        dep = dax.Dependency(parent=off_node._dax_node,
-                             child=efficiency_node._dax_node)
-        workflow._adag.addDependency(dep)
-        dep = dax.Dependency(parent=trig_cluster_node._dax_node,
-                             child=efficiency_node._dax_node)
-        workflow._adag.addDependency(dep)
-
-        # Adding inj_efficiency job
-        if do_injections:
-            for tag in injcombiner_out_tags:
-                if "_FILTERED_" in tag:
-                    inj_set_tag = [t for t in inj_tags if \
-                                   str(tag).replace("_FILTERED_", "") in t][0]
-                else:
-                    inj_set_tag = str(tag)
-
-                found_file = [file for file in injcombiner_outs \
-                              if tag + "_FOUND" in file.tag_str][0]
-                missed_file = [file for file in injcombiner_outs \
-                               if tag + "_MISSED" in file.tag_str][0]
-                inj_efficiency_node = inj_efficiency_jobs.create_node(\
-                        clust_file, offsource_clustered, segment_dir,
-                        found_file, missed_file, tags=[trial_tag, tag,
-                                                       inj_set_tag])
-                pp_nodes.append(inj_efficiency_node)
-                workflow.add_node(inj_efficiency_node)
-                dep = dax.Dependency(parent=off_node._dax_node,
-                                     child=inj_efficiency_node._dax_node)
-                workflow._adag.addDependency(dep)
-                for injcombiner_node in injcombiner_nodes:
-                    dep = dax.Dependency(parent=injcombiner_node._dax_node,
-                                         child=inj_efficiency_node._dax_node)
-                    workflow._adag.addDependency(dep)
-                for injfinder_node in injfinder_nodes:
-                    dep = dax.Dependency(parent=injfinder_node._dax_node,
-                                         child=inj_efficiency_node._dax_node)
-                    workflow._adag.addDependency(dep)
-
-        trial += 1
-
-    # Initialise html_summary class and set up job
-    #FIXME: We may want this job to run even if some jobs fail
-    html_summary_jobs = html_summary_class(cp, "html_summary", ifo=ifos,
-                                           out_dir=output_dir, tags=tags)
-    if do_injections:
-        tuning_tags = [inj_tag for inj_tag in injcombiner_out_tags \
-                       if "DETECTION" in inj_tag]
-        exclusion_tags = [inj_tag for inj_tag in injcombiner_out_tags \
-                          if "DETECTION" not in inj_tag]
-        html_summary_node = html_summary_jobs.create_node(c_file=config_file,
-                tuning_tags=tuning_tags, exclusion_tags=exclusion_tags,
-                seg_plot=segs_plot, html_dir=html_dir)
-    else:
-        html_summary_node = html_summary_jobs.create_node(c_file=config_file,
-                seg_plot=segs_plot, html_dir=html_dir)
-    workflow.add_node(html_summary_node)
-    for pp_node in pp_nodes:
-        dep = dax.Dependency(parent=pp_node._dax_node,
-                             child=html_summary_node._dax_node)
-        workflow._adag.addDependency(dep)
-
-    # Make the open box shell script
-    try:
-        open_box_cmd = html_summary_node.executable.get_pfn() + " "
-    except:
-        exe_path = html_summary_node.executable.get_pfn('nonlocal').replace(\
-                "https", "http")
-        exe_name = exe_path.rsplit('/', 1)[-1]
-        open_box_cmd = "wget %s\n" % exe_path
-        open_box_cmd += "chmod 500 ./%s\n./%s " % (exe_name, exe_name)
-    open_box_cmd += ' '.join(html_summary_node._args + \
-                             html_summary_node._options)
-    open_box_cmd += " --open-box"
-    open_box_path = "%s/open_the_box.sh" % output_dir
-    f = open(open_box_path, "w")
-    f.write("#!/bin/sh\n%s" % open_box_cmd)
-    f.close()
-    os.chmod(open_box_path, 0500)
-
-    pp_outs.extend(trig_cluster_outs)
-
-    return pp_outs
-
-
-def setup_postproc_coh_PTF_online_workflow(workflow, trig_files, trig_cache,
-        ts_trig_files, inj_trig_files, inj_files, inj_trig_caches, inj_caches,
-        config_file, output_dir, html_dir, segment_dir, segs_plot, ifos,
-        inj_tags=None, tags=None):
-    """
-    This module sets up a stripped down post-processing stage for the online
-    workflow, using a coh_PTF style set up. This consists of running
-    trig_combiner to find coherent triggers, and trig_cluster to cluster them.
-    This process may be done in two stages to reduce memory requirements. It
-    also runs injfinder to look for injections, and injcombiner to calculate
-    injection statistics. Finally, efficiency and sbv_plotter jobs calculate
-    efficiency and signal based veto statistics and make plots.
-    
-    Parameters
-    -----------
-    workflow : pycbc.workflow.core.Workflow
-        The Workflow instance that the coincidence jobs will be added to.
-    trig_files : pycbc.workflow.core.FileList
-        A FileList of the trigger files from the on/off source analysis jobs.
-    trig_cache : pycbc.workflow.core.File
-        A cache file pointing to the trigger files.
-    ts_trig_files : pycbc.workflow.core.FileList
-        A FileList of the trigger files from the timeslide analysis jobs.
-    inj_trig_files : pycbc.workflow.core.FileList
-        A FileList of the trigger files produced by injection jobs.
-    inj_files : pycbc.workflow.core.FileList
-        A FileList of the injection set files.
-    inj_trig_caches : pycbc.workflow.core.FileList
-        A FileList containing the cache files that point to the injection
-        trigger files.
-    inj_caches : pycbc.workflow.core.FileList
-        A FileList containing cache files that point to the injection files.
-    config_file : pycbc.workflow.core.File
-        The parsed configuration file.
-    output_dir : path
-        The directory in which output files will be stored.
-    html_dir : path
-        The directory where the result webpage will be placed.
-    segment_dir : path
-        The directory in which data segment information is stored.
-    segs_plot : pycbc.workflow.core.File
-        The plot showing the analysis segments for each IFO around the GRB time.
-        This is produced at the time of workflow generation.
-    ifos : list
-        A list containing the analysis interferometers.
-    inj_tags : list
-        List containing the strings used to uniquely identify the injection
-        sets included in the analysis.
-    tags : list of strings (optional, default = [])
-        A list of the tagging strings that will be used for all jobs created
-        by this call to the workflow. An example might be ['POSTPROC1'] or
-        ['DENTYSNEWPOSTPROC']. This will be used in output names.
-
-    Returns
-    --------
-    pp_outs : pycbc.workflow.core.FileList
-        A list of the output from this stage.
-    """
-    if inj_tags is None:
-        inj_tags = []
-    if tags is None:
-        tags = []
-    cp = workflow.cp
-    full_segment = trig_files[0].segment
-    trig_name = cp.get("workflow", "trigger-name")
-    grb_string = "GRB" + trig_name
-    num_trials = int(cp.get("trig_combiner", "num-trials"))
-    do_injections = cp.has_section("workflow-injections")
-
-    pp_outs = FileList([])
-    pp_nodes = []
-
-    # Set up needed exe classes
-    trig_combiner_class = select_generic_executable(workflow, "trig_combiner")
-
-    trig_cluster_class = select_generic_executable(workflow, "trig_cluster")
-
-    sbv_plotter_class = select_generic_executable(workflow, "sbv_plotter")
-    
-    efficiency_class = select_generic_executable(workflow, "efficiency")
-
-    #horizon_dist_class = select_generic_executable(workflow, "horizon_dist")
-
-    html_summary_class = select_generic_executable(workflow, "html_summary")
-
-    # Set up trig_combiner job
-    trig_combiner_out_tags = ["OFFSOURCE", "ONSOURCE", "ALL_TIMES"]
-    if all("COHERENT_NO_INJECTIONS" in t.name for t in trig_files) and \
-            cp.has_option_tag("inspiral", "do-short-slides",
-                              "coherent_no_injections"):
-        trig_combiner_out_tags.extend(["ZEROLAG_OFF", "ZEROLAG_ALL"])
-
     trig_combiner_jobs = trig_combiner_class(cp, "trig_combiner", ifo=ifos, 
                                              out_dir=output_dir, tags=tags)
 
@@ -824,15 +491,55 @@ def setup_postproc_coh_PTF_online_workflow(workflow, trig_files, trig_cache,
     trig_cluster_jobs = trig_cluster_class(cp, "trig_cluster", ifo=ifos,
                                            out_dir=output_dir, tags=tags)
 
+    # Initialise sbv_plotter class
+    sbv_plotter_outs = FileList([])
+    sbv_plotter_jobs = sbv_plotter_class(cp, "sbv_plotter", ifo=ifos,
+                                         out_dir=output_dir, tags=tags)
+
+    # Initialise efficiency class
+    efficiency_outs = FileList([])
+    efficiency_jobs = efficiency_class(cp, "efficiency", ifo=ifos,
+                                       out_dir=output_dir, tags=tags)
+
+    # Set up trig_cluster jobs
+    trig_cluster_nodes = []
+    for out_tag in trig_combiner_out_tags:
+        unclust_file = [f for f in trig_combiner_outs \
+                        if out_tag in f.tag_str][0]
+        trig_cluster_node, curr_outs = trig_cluster_jobs.create_node(\
+                unclust_file)
+        trig_cluster_outs.extend(curr_outs)
+        clust_file = curr_outs[0]
+        trig_cluster_nodes.append(trig_cluster_node)
+        pp_nodes.append(trig_cluster_node)
+        workflow.add_node(trig_cluster_node)
+        dep = dax.Dependency(parent=trig_combiner_node._dax_node,
+                             child=trig_cluster_node._dax_node)
+        workflow._adag.addDependency(dep)
+        # Are we not doing time slides?
+        if ts_trig_files is None:
+            if out_tag == "OFFSOURCE":
+                off_node = trig_cluster_node
+                offsource_clustered = clust_file
+
+            # Add sbv_plotter and efficiency jobs
+            workflow, pp_nodes = setup_coh_PTF_plotting_jobs(workflow, 
+                    unclust_file, clust_file, sbv_plotter_jobs,
+                    efficiency_jobs, inj_efficiency_jobs, off_node,
+                    trig_cluster_node, offsource_clustered, injfinder_nodes,
+                    injcombiner_nodes, injcombiner_outs,
+                    inj_sbv_plotter_parent_nodes, inj_tags,
+                    injcombiner_out_tags, pp_nodes, output_dir, segment_dir,
+                    ifos, out_tag, do_injs=do_injections, tags=tags)
+
+    # If doing time slides
     if ts_trig_files is not None:
-        # We have long timeslides, so process them too
         trig_combiner_ts_nodes = []
-        trig_cluster_ts_outs = FileList([])
-        ts_all_times_outs = FileList([out for out in trig_combiner_outs
+        trig_cluster_ts_nodes = []
+        trig_cluster_all_times_nodes = []
+        ts_all_times_outs = FileList([out for out in trig_cluster_outs
                                       if "ALL_TIMES" in out.tag_str])
-        ts_all_times_clust_outs = FileList([out for out in trig_cluster_outs
-                                            if "ALL_TIMES" in out.tag_str])
-        trig_combiner_ts_out_tags = ["OFFSOURCE", "ALL_TIMES"]
+        trig_combiner_ts_out_tags = ["ALL_TIMES", "OFFSOURCE"]
         ts_tags = list(set([[ts_tag for ts_tag in ts_trig_file.tags
                              if "SLIDE" in ts_tag][0]
                             for ts_trig_file in ts_trig_files]))
@@ -901,87 +608,53 @@ def setup_postproc_coh_PTF_online_workflow(workflow, trig_files, trig_cache,
                                 if ts_out_tag in f.tag_str][0]
                 trig_cluster_node, curr_outs = trig_cluster_jobs.create_node(\
                         unclust_file)
-                trig_cluster_ts_outs.extend(curr_outs)
+                trig_cluster_outs.extend(curr_outs)
                 clust_file = curr_outs[0]
+                trig_cluster_ts_nodes.append(trig_cluster_node)
                 pp_nodes.append(trig_cluster_node)
                 workflow.add_node(trig_cluster_node)
                 dep = dax.Dependency(parent=trig_combiner_ts_node._dax_node,
                                      child=trig_cluster_node._dax_node)
                 workflow._adag.addDependency(dep)        
+                if ts_out_tag == "ALL_TIMES":
+                    trig_cluster_all_times_nodes.append(trig_cluster_node)
+                    ts_all_times_outs.extend(FileList([clust_file]))
 
-            ts_all_times_clust_outs.extend(FileList([out for out in 
-                    trig_cluster_ts_outs if "ALL_TIMES" in out.tag_str]))
-
-        # Combine all offsources from timeslides
+        # Combine all timeslides
         trig_combiner_all_node, trig_combiner_all_outs = \
-                trig_combiner_jobs.create_node(ts_all_times_clust_outs, segment_dir,
-                            workflow.analysis_time,
+                trig_combiner_jobs.create_node(ts_all_times_outs, segment_dir,
+                            workflow.analysis_time, slide_tag="ALL_SLIDES",
                             out_tags=trig_combiner_ts_out_tags, tags=tags)
         pp_nodes.append(trig_combiner_all_node)
         workflow.add_node(trig_combiner_all_node)
-        for trig_combiner_ts_node in trig_combiner_ts_nodes:
-            dep = dax.Dependency(parent=trig_combiner_ts_node._dax_node,
+        for trig_cluster_ts_node in trig_cluster_all_times_nodes:
+            dep = dax.Dependency(parent=trig_cluster_ts_node._dax_node,
                                  child=trig_combiner_all_node._dax_node)
             workflow._adag.addDependency(dep)        
 
-    if do_injections:
-        workflow, injfinder_nodes, injfinder_outs, fm_cache, \
-                injcombiner_nodes, injcombiner_outs, injcombiner_out_tags, \
-                inj_sbv_plotter_parent_nodes, pp_nodes, pp_outs = \
-                setup_coh_PTF_injections_pp(workflow, inj_trig_files,
-                        inj_files, inj_trig_caches, inj_caches, pp_nodes,
-                        pp_outs, inj_tags, output_dir, segment_dir, ifos,
-                        tags=tags)
+        for out_tag in trig_combiner_ts_out_tags:
+            trig_cluster_outs = FileList([f for f in trig_cluster_outs
+                                          if out_tag not in f.tag_str])
+        trig_cluster_outs.extend(trig_combiner_all_outs)
+        off_node = trig_combiner_all_node
+        offsource_clustered = [f for f in trig_cluster_outs
+                               if "OFFSOURCE" in f.tag_str
+                               and "ZERO_LAG" not in f.tag_str][0]
 
-        # Initialise injection_efficiency class
-        inj_efficiency_jobs = efficiency_class(cp, "inj_efficiency", ifo=ifos,
-                                               out_dir=output_dir, tags=tags)
+        # Add sbv_plotter and efficiency jobs
+        for out_tag in trig_combiner_out_tags:
+            clust_file = [f for f in trig_cluster_outs \
+                          if out_tag in f.tag_str][0]
 
-    # Initialise sbv_plotter class
-    sbv_plotter_outs = FileList([])
-    sbv_plotter_jobs = sbv_plotter_class(cp, "sbv_plotter", ifo=ifos,
-                                         out_dir=output_dir, tags=tags)
+            workflow, pp_nodes = setup_coh_PTF_plotting_jobs(workflow, 
+                    unclust_file, clust_file, sbv_plotter_jobs,
+                    efficiency_jobs, inj_efficiency_jobs, off_node, off_node,
+                    offsource_clustered, injfinder_nodes, injcombiner_nodes,
+                    injcombiner_outs, inj_sbv_plotter_parent_nodes, inj_tags,
+                    injcombiner_out_tags, pp_nodes, output_dir, segment_dir,
+                    ifos, out_tag, do_injs=do_injections, tags=tags)
 
-    # Initialise efficiency class
-    efficiency_outs = FileList([])
-    efficiency_jobs = efficiency_class(cp, "efficiency", ifo=ifos,
-                                       out_dir=output_dir, tags=tags)
-
-    # Add trig_cluster jobs and their corresponding plotting jobs
-    for out_tag in trig_combiner_out_tags:
-        unclust_file = [f for f in trig_combiner_outs \
-                        if out_tag in f.tag_str][0]
-        trig_cluster_node, curr_outs = trig_cluster_jobs.create_node(\
-                unclust_file)
-        trig_cluster_outs.extend(curr_outs)
-        clust_file = curr_outs[0]
-        pp_nodes.append(trig_cluster_node)
-        workflow.add_node(trig_cluster_node)
-        dep = dax.Dependency(parent=trig_combiner_node._dax_node,
-                             child=trig_cluster_node._dax_node)
-        workflow._adag.addDependency(dep)
-
-        if out_tag == "OFFSOURCE":
-            offsource_clustered = clust_file
-            off_node = sbv_plotter_node
-
-        if ts_trig_files is not None:
-            final_trig_nodes = [trig_combiner_all_node]
-        else:
-            final_trig_nodes = [f for f in trig_cluster_nodes
-                                if out_tag in f.tag]
-        workflow, pp_nodes = setup_coh_PTF_plotting_jobs(workflow, 
-                unclust_file, clust_file, sbv_plotter_jobs, efficiency_jobs,
-                inj_efficiency_jobs, trig_cluster_node, off_node,
-                offsource_clustered, injfinder_nodes, injcombiner_nodes,
-                final_trig_nodes, injcombiner_outs,
-                inj_sbv_plotter_parent_nodes, inj_tags, injcombiner_out_tags,
-                pp_nodes, output_dir, segment_dir, ifos, out_tag,
-                do_injs=do_injections, tags=tags)
-
-    # Add further trig_cluster jobs for trials
     trial = 1
-
     while trial <= num_trials:
         trial_tag = "OFFTRIAL_%d" % trial
         unclust_file = [f for f in trig_combiner_outs \
@@ -1083,3 +756,4 @@ def setup_postproc_coh_PTF_online_workflow(workflow, trig_files, trig_cache,
     pp_outs.extend(trig_cluster_outs)
 
     return pp_outs
+

--- a/pylal/pygrb_cohptf_pp.py
+++ b/pylal/pygrb_cohptf_pp.py
@@ -421,9 +421,10 @@ def setup_postproc_coh_PTF_offline_workflow(workflow, trig_files, trig_cache,
 
     # Set up main trig_combiner class and tags
     trig_combiner_out_tags = ["OFFSOURCE", "ONSOURCE", "ALL_TIMES"]
-    if all("COHERENT_NO_INJECTIONS" in t.name for t in trig_files) and \
+    slides = all("COHERENT_NO_INJECTIONS" in t.name for t in trig_files) and \
             cp.has_option_tag("inspiral", "do-short-slides",
-                              "coherent_no_injections"):
+                              "coherent_no_injections")
+    if slides:
         trig_combiner_out_tags.extend(["ZEROLAG_OFF", "ZEROLAG_ALL"])
     
     trig_combiner_jobs = trig_combiner_class(cp, "trig_combiner", ifo=ifos, 
@@ -725,10 +726,10 @@ def setup_postproc_coh_PTF_offline_workflow(workflow, trig_files, trig_cache,
                           if "DETECTION" not in inj_tag]
         html_summary_node = html_summary_jobs.create_node(c_file=config_file,
                 tuning_tags=tuning_tags, exclusion_tags=exclusion_tags,
-                seg_plot=segs_plot, html_dir=html_dir)
+                seg_plot=segs_plot, html_dir=html_dir, time_slides=slides)
     else:
         html_summary_node = html_summary_jobs.create_node(c_file=config_file,
-                seg_plot=segs_plot, html_dir=html_dir)
+                seg_plot=segs_plot, html_dir=html_dir, time_slides=slides)
     workflow.add_node(html_summary_node)
     for pp_node in pp_nodes:
         dep = dax.Dependency(parent=pp_node._dax_node,


### PR DESCRIPTION
These changes update the `pygrb`-related code for running the O2 analysis. In particular they:
* fully incorporate 'long' timeslides into the analysis
* clean up the `pygrb` post-processing code
* correctly set the default value for an option in the `pylal_cbc_cohptf_efficiency` code
* fix a few minor bugs in the production of the result pages

These changes are made in conjunction with those in gwastro/pycbc#2143