### PR TITLE
Pygrb injection plot formatting fixes

### DIFF
--- a/bin/pylal_cbc_cohptf_efficiency
+++ b/bin/pylal_cbc_cohptf_efficiency
@@ -907,7 +907,9 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
         # Trigger is outside of mass bin
         gIFARStat[ix] = totalTrials
     gIFARStat = gIFARStat / totalTrials
-          
+    MF = np.argsort(gIFARStat)
+    FM = MF[::-1]
+
     gIFARm1           = foundInjm1[nonzeroFAP]
     gIFARm2           = foundInjm2[nonzeroFAP]
     gIFARRecm1        = foundTrigm1[nonzeroFAP]
@@ -1592,8 +1594,8 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
     if len(gMissed2Mchirp):
       ax.scatter(gMissed2Mchirp, gMissed2EffDist, c="r", marker="x", s=10)
     if len(gIFARMchirp):
-      p = ax.scatter(gIFARMchirp, gIFAREffDist, c=gIFARStat, vmin=0, vmax=1,
-                     s=40, edgecolor="w")
+      p = ax.scatter(gIFARMchirp[FM], gIFAREffDist[FM], c=gIFARStat[FM],
+                     vmin=0, vmax=1, s=40, edgecolor="w")
     if len(gFoundMchirp):
       ax.scatter(gFoundMchirp, gFoundEffDist, c=fnd_col, marker="+", s=30)
     if len(gIFARMchirp):
@@ -1612,8 +1614,8 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
     if len(gFoundMchirp):
       ax.scatter(gFoundMchirp, gFoundEffDist, c=fnd_col, marker="+", s=15)
     if len(gIFARMchirp):
-      p = ax.scatter(gIFARMchirp, gIFAREffDist, c=gIFARStat, vmin=0, vmax=1,
-                     s=40, edgecolor="w")
+      p = ax.scatter(gIFARMchirp[MF], gIFAREffDist[MF], c=gIFARStat[MF],
+                     vmin=0, vmax=1, s=40, edgecolor="w")
     if len(gMissed2Mchirp):
       ax.scatter(gMissed2Mchirp, gMissed2EffDist, c="r", marker="x", s=40)
     if len(missedInjMchirp):
@@ -1636,8 +1638,8 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
     if len(gMissed2Time):
       ax.scatter(gMissed2Time, gMissed2EffDist, c="r", marker='x', s=10)
     if len(gIFARTime):
-      p = ax.scatter(gIFARTime, gIFAREffDist, c=gIFARStat, vmin=0, vmax=1,
-                     s=40, edgecolor="w")
+      p = ax.scatter(gIFARTime[FM], gIFAREffDist[FM], c=gIFARStat[FM], vmin=0,
+                     vmax=1, s=40, edgecolor="w")
     if len(gFoundTime):
       ax.scatter(gFoundTime, gFoundEffDist, c=fnd_col, marker='+', s=30)
     if len(gIFARTime):
@@ -1657,8 +1659,8 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
     if len(gFoundTime):
       ax.scatter(gFoundTime, gFoundEffDist, c=fnd_col, marker='+', s=15)
     if len(gIFARTime):
-      p = ax.scatter(gIFARTime, gIFAREffDist, c=gIFARStat, vmin=0, vmax=1,
-                     s=40, edgecolor="w")
+      p = ax.scatter(gIFARTime[MF], gIFAREffDist[MF], c=gIFARStat[MF], vmin=0,
+                     vmax=1, s=40, edgecolor="w")
     if len(gMissed2Time):
       ax.scatter(gMissed2Time, gMissed2EffDist, c="r", marker='x', s=40)
     if len(missedInjTime):
@@ -1682,8 +1684,8 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
     if len(gMissed2Mchirp):
       ax.scatter(gMissed2Mchirp, gMissed2Dist, c="r", marker="x", s=10)
     if len(gIFARMchirp):
-      p = ax.scatter(gIFARMchirp, gIFARDist, c=gIFARStat, vmin=0, vmax=1,
-                     s=40, edgecolor="w")
+      p = ax.scatter(gIFARMchirp[FM], gIFARDist[FM], c=gIFARStat[FM], vmin=0,
+                     vmax=1, s=40, edgecolor="w")
     if len(gFoundMchirp):
       ax.scatter(gFoundMchirp, gFoundDist, c=fnd_col, marker="+", s=30)
     if len(gIFARMchirp):
@@ -1702,8 +1704,8 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
     if len(gFoundMchirp):
       ax.scatter(gFoundMchirp, gFoundDist, c=fnd_col, marker="+", s=15)
     if len(gIFARMchirp):
-      p = ax.scatter(gIFARMchirp, gIFARDist, c=gIFARStat, vmin=0, vmax=1,
-                     s=40, edgecolor="w")
+      p = ax.scatter(gIFARMchirp[MF], gIFARDist[MF], c=gIFARStat[MF], vmin=0,
+                     vmax=1, s=40, edgecolor="w")
     if len(gMissed2Mchirp):
       ax.scatter(gMissed2Mchirp, gMissed2Dist, c="r", marker="x", s=40)
     if len(missedInjMchirp):
@@ -1726,8 +1728,8 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
     if len(gMissed2Time):
       ax.scatter(gMissed2Time, gMissed2Dist, c="r", marker='x', s=10)
     if len(gIFARTime):
-      p = ax.scatter(gIFARTime, gIFARDist, c=gIFARStat, vmin=0, vmax=1,
-                     s=40, edgecolor="w")
+      p = ax.scatter(gIFARTime[FM], gIFARDist[FM], c=gIFARStat[FM], vmin=0,
+                     vmax=1, s=40, edgecolor="w")
     if len(gFoundTime):
       ax.scatter(gFoundTime, gFoundDist, c=fnd_col, marker='+', s=30)
     if len(gIFARTime):
@@ -1747,8 +1749,8 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
     if len(gFoundTime):
       ax.scatter(gFoundTime, gFoundDist, c=fnd_col, marker='+', s=15)
     if len(gIFARTime):
-      p = ax.scatter(gIFARTime, gIFARDist, c=gIFARStat, vmin=0, vmax=1,
-                     s=40, edgecolor="w")
+      p = ax.scatter(gIFARTime[MF], gIFARDist[MF], c=gIFARStat[MF], vmin=0,
+                     vmax=1, s=40, edgecolor="w")
     if len(gMissed2Time):
       ax.scatter(gMissed2Time, gMissed2Dist, c="r", marker='x', s=40)
     if len(missedInjTime):
@@ -1778,8 +1780,8 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
         ax.scatter(gMissed2Mchirp, gMissed2EffSiteDist[site], c="r", s=10,
                    marker="x")
       if len(gIFARMchirp):
-        p = ax.scatter(gIFARMchirp, gIFAREffSiteDist[site], c=gIFARStat, s=40,
-                       vmin=0, vmax=1, edgecolor="w")
+        p = ax.scatter(gIFARMchirp[FM], gIFAREffSiteDist[site][FM],
+                       c=gIFARStat[FM], s=40, vmin=0, vmax=1, edgecolor="w")
       if len(gFoundMchirp):
         ax.scatter(gFoundMchirp, gFoundEffSiteDist[site], c=fnd_col, s=30,
                    marker="+")
@@ -1800,8 +1802,8 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
         ax.scatter(gFoundMchirp, gFoundEffSiteDist[site], c=fnd_col, s=15,
                    marker="+")
       if len(gIFARMchirp):
-        p = ax.scatter(gIFARMchirp, gIFAREffSiteDist[site], c=gIFARStat, s=40,
-                       vmin=0, vmax=1, edgecolor="w")
+        p = ax.scatter(gIFARMchirp[MF], gIFAREffSiteDist[site][MF],
+                       c=gIFARStat[MF], s=40, vmin=0, vmax=1, edgecolor="w")
       if len(gMissed2Mchirp):
         ax.scatter(gMissed2Mchirp, gMissed2EffSiteDist[site], c="r", s=40,
                    marker="x")
@@ -1828,8 +1830,8 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
         ax.scatter(gMissed2Time, gMissed2EffSiteDist[site], c="r", s=10,
                    marker="x")
       if len(gIFARTime):
-        p = ax.scatter(gIFARTime, gIFAREffSiteDist[site], c=gIFARStat, s=40,
-                       vmin=0, vmax=1, edgecolor="w")
+        p = ax.scatter(gIFARTime[FM], gIFAREffSiteDist[site][FM],
+                       c=gIFARStat[FM], s=40, vmin=0, vmax=1, edgecolor="w")
       if len(gFoundTime):
         ax.scatter(gFoundTime, gFoundEffSiteDist[site], c=fnd_col, s=30,
                    marker="+")
@@ -1851,8 +1853,8 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
         ax.scatter(gFoundTime, gFoundEffSiteDist[site], c=fnd_col, s=15,
                    marker="+")
       if len(gIFARTime):
-        p = ax.scatter(gIFARTime, gIFAREffSiteDist[site], c=gIFARStat, s=40,
-                       vmin=0, vmax=1, edgecolor="w")
+        p = ax.scatter(gIFARTime[MF], gIFAREffSiteDist[site][MF],
+                       c=gIFARStat[MF], s=40, vmin=0, vmax=1, edgecolor="w")
       if len(gMissed2Time):
         ax.scatter(gMissed2Time, gMissed2EffSiteDist[site], c="r", s=40,
                    marker="x")
@@ -1887,8 +1889,8 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
     if len(gIFARSpin1x):
       gIFARSpin1 = np.sqrt(gIFARSpin1x**2 + gIFARSpin1y**2 + gIFARSpin1z**2)
       gIFARSpin2 = np.sqrt(gIFARSpin2x**2 + gIFARSpin2y**2 + gIFARSpin2z**2)
-      p = ax.scatter(gIFARSpin1, gIFARSpin2, c=gIFARStat, s=40, vmin=0, vmax=1,
-                     edgecolor="w")
+      p = ax.scatter(gIFARSpin1[MF], gIFARSpin2[MF], c=gIFARStat[MF], s=40,
+                     vmin=0, vmax=1, edgecolor="w")
     if len(gMissed2Spin1x):
       gMissed2Spin1 = np.sqrt(gMissed2Spin1x**2 + gMissed2Spin1y**2 + \
                               gMissed2Spin1z**2)
@@ -1930,8 +1932,8 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
     if len(gFoundm1):
       ax.scatter(gFoundq, gFoundM, c=fnd_col, s=15, marker="+")
     if len(gIFARm1):
-      p = ax.scatter(gIFARq, gIFARM, c=gIFARStat, s=40, vmin=0, vmax=1,
-                     edgecolor="w")
+      p = ax.scatter(gIFARq[MF], gIFARM[MF], c=gIFARStat[MF], s=40, vmin=0,
+                     vmax=1, edgecolor="w")
     if len(gMissed2m1):
       ax.scatter(gMissed2q, gMissed2M, c="r", s=40, marker="x")
     if len(missedInjm1):
@@ -1965,8 +1967,8 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
       ax.scatter(np.rad2deg(gFoundInc2), gFoundMchirp, c=fnd_col, s=15,
                  marker="+")
     if len(gIFARInc):
-      p = ax.scatter(np.rad2deg(gIFARInc2), gIFARMchirp, c=gIFARStat, s=40,
-                     vmin=0, vmax=1, edgecolor="w")
+      p = ax.scatter(np.rad2deg(gIFARInc2[MF]), gIFARMchirp[MF], s=40,
+                     c=gIFARStat[MF], vmin=0, vmax=1, edgecolor="w")
     if len(gMissed2Inc):
       ax.scatter(np.rad2deg(gMissed2Inc2), gMissed2Mchirp, c="r", s=40,
                  marker="x")
@@ -1989,8 +1991,8 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
     if len(gFoundInc):
       ax.scatter(np.cos(gFoundInc2), gFoundDist, c=fnd_col, s=15, marker="+")
     if len(gIFARInc):
-      p = ax.scatter(np.cos(gIFARInc2), gIFARDist, c=gIFARStat, s=40, vmin=0,
-                     vmax=1, edgecolor="w")
+      p = ax.scatter(np.cos(gIFARInc2[MF]), gIFARDist[MF], c=gIFARStat[MF],
+                     s=40, vmin=0, vmax=1, edgecolor="w")
     if len(gMissed2Inc):
       ax.scatter(np.cos(gMissed2Inc2), gMissed2Dist, c="r", s=40, marker="x")
     if len(missedInjInc):

--- a/bin/pylal_cbc_cohptf_efficiency
+++ b/bin/pylal_cbc_cohptf_efficiency
@@ -1597,14 +1597,13 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
       ax.scatter(missedInjMchirp, missedInjEffDist, c="k", marker='x',\
                  edgecolors='k')
     ax.grid()
-    ax.semilogy()
+    ax.set_yscale("log")
     if len(gIFARMchirp):
       cb = ax.figure.colorbar(p)
       cb.ax.set_ylabel("FAP")
     ax.set_xlabel("Mchirp")
     ax.set_ylabel("Inverse sum of effective distances")
     ax.set_title("Injections found louder than loudest background event")
-    #ax.set_ylim([ 0.5, 1000 ])
     fig.savefig('%s/found_missed_injections_effdist.png' % outdir)
     plt.close()
 
@@ -1624,14 +1623,13 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
       ax.scatter(gFoundMchirp, gFoundEffDist, c="b", marker='x',\
                  edgecolors='g')
     ax.grid()
-    ax.semilogy()
+    ax.set_yscale("log")
     if len(gIFARMchirp):
       cb = ax.figure.colorbar(p)
       cb.ax.set_ylabel("FAP")
     ax.set_xlabel("Mchirp")
     ax.set_ylabel("Inverse sum of effective distances")
     ax.set_title("Injections found louder than loudest background event")
-    #ax.set_ylim([ 0.5, 1000 ])
     fig.savefig('%s/missed_found_injections_effdist.png' % outdir)
     plt.close()
 
@@ -1650,7 +1648,7 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
       ax.scatter(missedInjTime, missedInjEffDist, c="k", marker='x',\
                  edgecolors='k')
     ax.grid()
-    ax.semilogy()
+    ax.set_yscale("log")
     if len(gIFARTime):
       cb = ax.figure.colorbar(p)
       cb.ax.set_ylabel("FAP")
@@ -1658,7 +1656,6 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
     ax.set_ylabel("Inverse sum of effective distances")
     ax.set_title("Injections found louder than loudest background event")
     ax.set_xlim([ start, end ])
-    #ax.set_ylim([ 0.5, 1000 ])
     fig.savefig("%s/found_missed_injections_effdist_time.png" % outdir)
     plt.close()
 
@@ -1677,7 +1674,7 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
     if len(gFoundTime):
       ax.scatter(gFoundTime, gFoundEffDist, c="b", marker='x', edgecolors='g')
     ax.grid()
-    ax.semilogy()
+    ax.set_yscale("log")
     if len(gIFARTime):
       cb = ax.figure.colorbar(p)
       cb.ax.set_ylabel("FAP")
@@ -1685,7 +1682,6 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
     ax.set_ylabel("Inverse sum of effective distances")
     ax.set_title("Injections found louder than loudest background event")
     ax.set_xlim([ start, end ])
-    #ax.set_ylim([ 0.5, 1000 ])
     fig.savefig("%s/missed_found_injections_effdist_time.png" % outdir)
     plt.close()
 
@@ -1811,14 +1807,13 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
         p = ax.scatter(gIFARMchirp, gIFAREffSiteDist[site],\
                       c=gIFARStat, norm=colors.Normalize(0,1,clip=False),\
                       marker='o', edgecolors='none')
-      ax.semilogy()
+      ax.set_yscale("log")
       if len(gIFARMchirp):
         cb = ax.figure.colorbar(p)
         cb.ax.set_ylabel("FAP")
       ax.set_xlabel("Mchirp")
       ax.set_ylabel("%s effective distance" % sitename[site])
       ax.set_title("Injections found louder than loudest background event")
-      #ax.set_ylim([ 0.5, 1000 ])
       fig.savefig("%s/found_missed_injections_effdist_%s.png"\
                    % (outdir, site.lower()))
       plt.close()
@@ -1839,7 +1834,7 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
         p = ax.scatter(gIFARTime ,gIFAREffSiteDist[site],\
                       c=gIFARStat, norm=colors.Normalize(0,1,clip=False),\
                       marker='o', edgecolors='none')
-      ax.semilogy()
+      ax.set_yscale("log")
       if len(gIFARTime):
         cb = ax.figure.colorbar(p)
         cb.ax.set_ylabel("FAP")
@@ -1847,7 +1842,6 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
       ax.set_ylabel("%s effective distance" % sitename[site])
       ax.set_title("Injections found louder than loudest background event")
       ax.set_xlim([ start, end ])
-      #ax.set_ylim([ 0.5, 1000 ])
       fig.savefig("%s/found_missed_injections_effdist_time_%s.png"\
                    % (outdir, site.lower()))
       plt.close()
@@ -1866,14 +1860,13 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
       p = ax.scatter(gIFARMchirp, gIFARDist, c=gIFARStat,\
                     norm=colors.Normalize(0,1,clip=False),\
                     marker='o', edgecolors='none')
-    ax.semilogy()
+    ax.set_yscale("log")
     if len(gIFARMchirp):
       cb = ax.figure.colorbar(p)
       cb.ax.set_ylabel("FAP")
     ax.set_xlabel("Mchirp")
     ax.set_ylabel("Distance (Mpc)")
     ax.set_title("Injections found louder than loudest background event")
-    #ax.set_ylim([ 0.5, 100 ])
     fig.savefig("%s/found_missed_injections_dist.png" % outdir)
     plt.close()
   
@@ -1891,7 +1884,7 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
       p = ax.scatter(gIFARTime, gIFARDist, c=gIFARStat,\
                     norm=colors.Normalize(0,1,clip=False),\
                     marker='o', edgecolors='none')
-    ax.semilogy()
+    ax.set_yscale("log")
     if len(gIFARTime):
       cb = ax.figure.colorbar(p)
       cb.ax.set_ylabel("FAP")
@@ -1899,7 +1892,6 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
     ax.set_ylabel("Distance (Mpc)")
     ax.set_title("Injections found louder than loudest background event")
     ax.set_xlim([ start, end ])
-    #ax.set_ylim([ 0.5, 100 ])
     fig.savefig("%s/found_missed_injections_dist_time.png" % outdir)
     plt.close()
 

--- a/bin/pylal_cbc_cohptf_efficiency
+++ b/bin/pylal_cbc_cohptf_efficiency
@@ -1582,33 +1582,7 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
 
     # plot found/missed injections
     fig = plt.figure()
-    ax = fig.gca()
-    if len(gFoundMchirp):
-      ax.scatter(gFoundMchirp, gFoundEffDist, c="g", marker='x',\
-                 edgecolors='g')
-    if len(gIFARMchirp):
-      p = ax.scatter(gIFARMchirp, gIFAREffDist, c=gIFARStat,\
-                     norm=colors.Normalize(0,1,clip=False), marker='o',\
-                     edgecolors='none')
-    if len(gMissed2Mchirp):
-      ax.scatter(gMissed2Mchirp, gMissed2EffDist, c="r", marker='x',\
-                 edgecolors='r')
-    if len(missedInjMchirp):
-      ax.scatter(missedInjMchirp, missedInjEffDist, c="k", marker='x',\
-                 edgecolors='k')
-    ax.grid()
-    ax.set_yscale("log")
-    if len(gIFARMchirp):
-      cb = ax.figure.colorbar(p)
-      cb.ax.set_ylabel("FAP")
-    ax.set_xlabel("Mchirp")
-    ax.set_ylabel("Inverse sum of effective distances")
-    ax.set_title("Injections found louder than loudest background event")
-    fig.savefig('%s/found_missed_injections_effdist.png' % outdir)
-    plt.close()
-
-    fig = plt.figure()
-    ax = fig.gca()
+    ax = fig.gca(yscale="log")
     if len(missedInjMchirp):
       ax.scatter(missedInjMchirp, missedInjEffDist, c="k", marker='x',\
                  edgecolors='k')
@@ -1621,9 +1595,32 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
                      edgecolors='none')
     if len(gFoundMchirp):
       ax.scatter(gFoundMchirp, gFoundEffDist, c="b", marker='x',\
-                 edgecolors='g')
+                 edgecolors='b')
     ax.grid()
-    ax.set_yscale("log")
+    if len(gIFARMchirp):
+      cb = plt.colorbar(p, label="FAP")
+    ax.set_xlabel("Mchirp")
+    ax.set_ylabel("Inverse sum of effective distances")
+    ax.set_title("Injections found louder than loudest background event")
+    fig.savefig('%s/found_missed_injections_effdist.png' % outdir)
+    plt.close()
+
+    fig = plt.figure()
+    ax = fig.gca(yscale="log")
+    if len(gFoundMchirp):
+      ax.scatter(gFoundMchirp, gFoundEffDist, c="b", marker='x',\
+                 edgecolors='b')
+    if len(gIFARMchirp):
+      p = ax.scatter(gIFARMchirp, gIFAREffDist, c=gIFARStat,\
+                     norm=colors.Normalize(0,1,clip=False), marker='o',\
+                     edgecolors='none')
+    if len(gMissed2Mchirp):
+      ax.scatter(gMissed2Mchirp, gMissed2EffDist, c="r", marker='x',\
+                 edgecolors='r')
+    if len(missedInjMchirp):
+      ax.scatter(missedInjMchirp, missedInjEffDist, c="k", marker='x',\
+                 edgecolors='k')
+    ax.grid()
     if len(gIFARMchirp):
       cb = ax.figure.colorbar(p)
       cb.ax.set_ylabel("FAP")
@@ -1634,21 +1631,20 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
     plt.close()
 
     fig = plt.figure()
-    ax = fig.gca()
-    if len(gFoundTime):
-      ax.scatter(gFoundTime, gFoundEffDist, c="b", marker='x', edgecolors='g')
+    ax = fig.gca(yscale="log")
+    if len(missedInjTime):
+      ax.scatter(missedInjTime, missedInjEffDist, c="k", marker='x',\
+                 edgecolors='k')
+    if len(gMissed2Time):
+      ax.scatter(gMissed2Time, gMissed2EffDist, c="r", marker='x',\
+                 edgecolors='r')
     if len(gIFARTime):
       p = ax.scatter(gIFARTime, gIFAREffDist, c=gIFARStat,\
                      norm=colors.Normalize(0,1,clip=False), marker='o',\
                      edgecolors='none')
-    if len(gMissed2Time):
-      ax.scatter(gMissed2Time, gMissed2EffDist, c="r", marker='x',\
-                 edgecolors='r')
-    if len(missedInjTime):
-      ax.scatter(missedInjTime, missedInjEffDist, c="k", marker='x',\
-                 edgecolors='k')
+    if len(gFoundTime):
+      ax.scatter(gFoundTime, gFoundEffDist, c="b", marker='x', edgecolors='b')
     ax.grid()
-    ax.set_yscale("log")
     if len(gIFARTime):
       cb = ax.figure.colorbar(p)
       cb.ax.set_ylabel("FAP")
@@ -1660,21 +1656,20 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
     plt.close()
 
     fig = plt.figure()
-    ax = fig.gca()
-    if len(missedInjTime):
-      ax.scatter(missedInjTime, missedInjEffDist, c="k", marker='x',\
-                 edgecolors='k')
-    if len(gMissed2Time):
-      ax.scatter(gMissed2Time, gMissed2EffDist, c="r", marker='x',\
-                 edgecolors='r')
+    ax = fig.gca(yscale="log")
+    if len(gFoundTime):
+      ax.scatter(gFoundTime, gFoundEffDist, c="b", marker='x', edgecolors='b')
     if len(gIFARTime):
       p = ax.scatter(gIFARTime, gIFAREffDist, c=gIFARStat,\
                      norm=colors.Normalize(0,1,clip=False), marker='o',\
                      edgecolors='none')
-    if len(gFoundTime):
-      ax.scatter(gFoundTime, gFoundEffDist, c="b", marker='x', edgecolors='g')
+    if len(gMissed2Time):
+      ax.scatter(gMissed2Time, gMissed2EffDist, c="r", marker='x',\
+                 edgecolors='r')
+    if len(missedInjTime):
+      ax.scatter(missedInjTime, missedInjEffDist, c="k", marker='x',\
+                 edgecolors='k')
     ax.grid()
-    ax.set_yscale("log")
     if len(gIFARTime):
       cb = ax.figure.colorbar(p)
       cb.ax.set_ylabel("FAP")
@@ -1693,19 +1688,6 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
                             foundInjSpin1z**2)
     foundInjSpin2 = np.sqrt(foundInjSpin2x**2 + foundInjSpin2y**2 + \
                             foundInjSpin2z**2)
-    if len(gFoundSpin1x):
-      gFoundSpin1 = np.sqrt(gFoundSpin1x**2 + gFoundSpin1y**2 + \
-                            gFoundSpin1z**2)
-      gFoundSpin2 = np.sqrt(gFoundSpin2x**2 + gFoundSpin2y**2 + \
-                            gFoundSpin2z**2)
-      ax.scatter(gFoundSpin1, gFoundSpin2, c="g", marker="x",
-                 edgecolors="g")
-    if len(gIFARSpin1x):
-      gIFARSpin1 = np.sqrt(gIFARSpin1x**2 + gIFARSpin1y**2 + gIFARSpin1z**2)
-      gIFARSpin2 = np.sqrt(gIFARSpin2x**2 + gIFARSpin2y**2 + gIFARSpin2z**2)
-      p = ax.scatter(gIFARSpin1, gIFARSpin2, c=gIFARStat,
-                     norm=colors.Normalize(0, 1, clip=False), marker="o",
-                     edgecolors="none")
     if len(missedInjSpin1x):
       ax.scatter(missedInjSpin1, missedInjSpin2, c="k", marker="x",
                  edgecolors="k")
@@ -1716,6 +1698,19 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
                               gMissed2Spin2z**2)
       ax.scatter(gMissed2Spin1, gMissed2Spin2, c="r", marker="x",
                  edgecolors="r")
+    if len(gIFARSpin1x):
+      gIFARSpin1 = np.sqrt(gIFARSpin1x**2 + gIFARSpin1y**2 + gIFARSpin1z**2)
+      gIFARSpin2 = np.sqrt(gIFARSpin2x**2 + gIFARSpin2y**2 + gIFARSpin2z**2)
+      p = ax.scatter(gIFARSpin1, gIFARSpin2, c=gIFARStat,
+                     norm=colors.Normalize(0, 1, clip=False), marker="o",
+                     edgecolors="none")
+    if len(gFoundSpin1x):
+      gFoundSpin1 = np.sqrt(gFoundSpin1x**2 + gFoundSpin1y**2 + \
+                            gFoundSpin1z**2)
+      gFoundSpin2 = np.sqrt(gFoundSpin2x**2 + gFoundSpin2y**2 + \
+                            gFoundSpin2z**2)
+      ax.scatter(gFoundSpin1, gFoundSpin2, c="g", marker="x",
+                 edgecolors="g")
     if len(gIFARSpin1x):
       cb = ax.figure.colorbar(p)
       cb.ax.set_ylabel("FAP")
@@ -1733,15 +1728,15 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
     fig = plt.figure()
     ax = fig.gca()
     ax.grid()
-    if len(gFoundm1):
-      ax.scatter(gFoundm1, gFoundm2, c="g", marker="x", edgecolors="g")
-    if len(gIFARm1):
-      p = ax.scatter(gIFARm1, gIFARm2, c=gIFARStat, edgecolors="none",
-                     norm=colors.Normalize(0, 1, clip=False), marker="o")
     if len(missedInjm1):
       ax.scatter(missedInjm1, missedInjm2, c="k", marker="x", edgecolors="k")
     if len(gMissed2m1):
       ax.scatter(gMissed2m1, gMissed2m2, c="r", marker="x", edgecolors="r")
+    if len(gIFARm1):
+      p = ax.scatter(gIFARm1, gIFARm2, c=gIFARStat, edgecolors="none",
+                     norm=colors.Normalize(0, 1, clip=False), marker="o")
+    if len(gFoundm1):
+      ax.scatter(gFoundm1, gFoundm2, c="b", marker="x", edgecolors="b")
     if len(gIFARm1):
       cb = ax.figure.colorbar(p)
       cb.ax.set_ylabel("FAP")
@@ -1759,17 +1754,17 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
     fig = plt.figure()
     ax = fig.gca()
     ax.grid()
-    if len(gFoundInc):
-      ax.scatter(gFoundMchirp, gFoundInc, c="g", marker="x", edgecolors="g")
-    if len(gIFARInc):
-      p = ax.scatter(gIFARMchirp, gIFARInc, c=gIFARStat, edgecolors="none",
-                     norm=colors.Normalize(0, 1, clip=False), marker="o")
-    if len(gMissed2Inc):
-      ax.scatter(gMissed2Mchirp, gMissed2Inc, c="r", marker="x",
-                 edgecolors="r")
     if len(missedInjInc):
       ax.scatter(missedInjMchirp, missedInjInc, c="k", marker="x",
                  edgecolors="k")
+    if len(gMissed2Inc):
+      ax.scatter(gMissed2Mchirp, gMissed2Inc, c="r", marker="x",
+                 edgecolors="r")
+    if len(gIFARInc):
+      p = ax.scatter(gIFARMchirp, gIFARInc, c=gIFARStat, edgecolors="none",
+                     norm=colors.Normalize(0, 1, clip=False), marker="o")
+    if len(gFoundInc):
+      ax.scatter(gFoundMchirp, gFoundInc, c="b", marker="x", edgecolors="b")
     if len(gIFARInc):
       cb = ax.figure.colorbar(p)
       cb.ax.set_ylabel("FAP")
@@ -1792,25 +1787,24 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
 
     for site in sites:
       fig = plt.figure()
-      ax = fig.gca()
+      ax = fig.gca(yscale="log")
       if len(missedInjMchirp):
         ax.scatter(missedInjMchirp, missedInjEffSiteDist[site],\
                    c="k", marker='x', edgecolors='k')
       if len(gMissed2Mchirp):
         ax.scatter(gMissed2Mchirp, gMissed2EffSiteDist[site],\
                   c="r", marker='x', edgecolors='r')
-      if len(gFoundMchirp):
-        ax.scatter(gFoundMchirp, gFoundEffSiteDist[site],\
-                  c="b", marker='x', edgecolors='g')
-      ax.grid()
       if len(gIFARMchirp):
         p = ax.scatter(gIFARMchirp, gIFAREffSiteDist[site],\
                       c=gIFARStat, norm=colors.Normalize(0,1,clip=False),\
                       marker='o', edgecolors='none')
-      ax.set_yscale("log")
+      if len(gFoundMchirp):
+        ax.scatter(gFoundMchirp, gFoundEffSiteDist[site],\
+                  c="b", marker='x', edgecolors='b')
       if len(gIFARMchirp):
         cb = ax.figure.colorbar(p)
         cb.ax.set_ylabel("FAP")
+      ax.grid()
       ax.set_xlabel("Mchirp")
       ax.set_ylabel("%s effective distance" % sitename[site])
       ax.set_title("Injections found louder than loudest background event")
@@ -1819,25 +1813,50 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
       plt.close()
 
       fig = plt.figure()
-      ax  = fig.gca()
+      ax = fig.gca(yscale="log")
+      if len(gFoundMchirp):
+        ax.scatter(gFoundMchirp, gFoundEffSiteDist[site],\
+                  c="b", marker='x', edgecolors='b')
+      if len(gIFARMchirp):
+        p = ax.scatter(gIFARMchirp, gIFAREffSiteDist[site],\
+                      c=gIFARStat, norm=colors.Normalize(0,1,clip=False),\
+                      marker='o', edgecolors='none')
+      if len(gMissed2Mchirp):
+        ax.scatter(gMissed2Mchirp, gMissed2EffSiteDist[site],\
+                  c="r", marker='x', edgecolors='r')
+      if len(missedInjMchirp):
+        ax.scatter(missedInjMchirp, missedInjEffSiteDist[site],\
+                   c="k", marker='x', edgecolors='k')
+      if len(gIFARMchirp):
+        cb = ax.figure.colorbar(p)
+        cb.ax.set_ylabel("FAP")
+      ax.grid()
+      ax.set_xlabel("Mchirp")
+      ax.set_ylabel("%s effective distance" % sitename[site])
+      ax.set_title("Injections found louder than loudest background event")
+      fig.savefig("%s/missed_found_injections_effdist_%s.png"\
+                   % (outdir, site.lower()))
+      plt.close()
+
+      fig = plt.figure()
+      ax = fig.gca(yscale="log")
       if len(missedInjTime):
         ax.scatter(missedInjTime, missedInjEffSiteDist[site],\
                   c="k", marker='x', edgecolors='k')
       if len(gMissed2Time):
         ax.scatter(gMissed2Time, gMissed2EffSiteDist[site],\
                   c="r", marker='x', edgecolors='r')
-      if len(gFoundTime):
-        ax.scatter(gFoundTime, gFoundEffSiteDist[site],\
-                  c="b", marker='x', edgecolors='g')
-      ax.grid()
       if len(gIFARTime):
         p = ax.scatter(gIFARTime ,gIFAREffSiteDist[site],\
                       c=gIFARStat, norm=colors.Normalize(0,1,clip=False),\
                       marker='o', edgecolors='none')
-      ax.set_yscale("log")
+      if len(gFoundTime):
+        ax.scatter(gFoundTime, gFoundEffSiteDist[site],\
+                  c="b", marker='x', edgecolors='b')
       if len(gIFARTime):
         cb = ax.figure.colorbar(p)
         cb.ax.set_ylabel("FAP")
+      ax.grid()
       ax.set_xlabel("Time since %d" % grbTime)
       ax.set_ylabel("%s effective distance" % sitename[site])
       ax.set_title("Injections found louder than loudest background event")
@@ -1845,54 +1864,126 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
       fig.savefig("%s/found_missed_injections_effdist_time_%s.png"\
                    % (outdir, site.lower()))
       plt.close()
-  
+
+      fig = plt.figure()
+      ax = fig.gca(yscale="log")
+      if len(gFoundTime):
+        ax.scatter(gFoundTime, gFoundEffSiteDist[site],\
+                  c="b", marker='x', edgecolors='b')
+      if len(gIFARTime):
+        p = ax.scatter(gIFARTime ,gIFAREffSiteDist[site],\
+                      c=gIFARStat, norm=colors.Normalize(0,1,clip=False),\
+                      marker='o', edgecolors='none')
+      if len(gMissed2Time):
+        ax.scatter(gMissed2Time, gMissed2EffSiteDist[site],\
+                  c="r", marker='x', edgecolors='r')
+      if len(missedInjTime):
+        ax.scatter(missedInjTime, missedInjEffSiteDist[site],\
+                  c="k", marker='x', edgecolors='k')
+      if len(gIFARTime):
+        cb = ax.figure.colorbar(p)
+        cb.ax.set_ylabel("FAP")
+      ax.grid()
+      ax.set_xlabel("Time since %d" % grbTime)
+      ax.set_ylabel("%s effective distance" % sitename[site])
+      ax.set_title("Injections found louder than loudest background event")
+      ax.set_xlim([ start, end ])
+      fig.savefig("%s/missed_found_injections_effdist_time_%s.png"\
+                   % (outdir, site.lower()))
+      plt.close()
+
     fig = plt.figure()
-    ax = fig.gca()
+    ax = fig.gca(yscale="log")
     if len(missedInjMchirp):
       ax.scatter(missedInjMchirp, missedInjDist,c="k", marker='x', edgecolors='k')
     if len(gMissed2Mchirp):
       ax.scatter(gMissed2Mchirp, gMissed2Dist,c="r", marker='x',\
                   edgecolors='r')
-    if len(gFoundMchirp):
-      ax.scatter(gFoundMchirp, gFoundDist, c="b", marker='x', edgecolors='g')
-    ax.grid()
     if len(gIFARMchirp):
       p = ax.scatter(gIFARMchirp, gIFARDist, c=gIFARStat,\
                     norm=colors.Normalize(0,1,clip=False),\
                     marker='o', edgecolors='none')
-    ax.set_yscale("log")
+    if len(gFoundMchirp):
+      ax.scatter(gFoundMchirp, gFoundDist, c="b", marker='x', edgecolors='b')
     if len(gIFARMchirp):
       cb = ax.figure.colorbar(p)
       cb.ax.set_ylabel("FAP")
+    ax.grid()
     ax.set_xlabel("Mchirp")
     ax.set_ylabel("Distance (Mpc)")
     ax.set_title("Injections found louder than loudest background event")
     fig.savefig("%s/found_missed_injections_dist.png" % outdir)
     plt.close()
-  
+
     fig = plt.figure()
-    ax = fig.gca()
+    ax = fig.gca(yscale="log")
+    if len(gFoundMchirp):
+      ax.scatter(gFoundMchirp, gFoundDist, c="b", marker='x', edgecolors='b')
+    if len(gIFARMchirp):
+      p = ax.scatter(gIFARMchirp, gIFARDist, c=gIFARStat,\
+                    norm=colors.Normalize(0,1,clip=False),\
+                    marker='o', edgecolors='none')
+    if len(gMissed2Mchirp):
+      ax.scatter(gMissed2Mchirp, gMissed2Dist,c="r", marker='x',\
+                  edgecolors='r')
+    if len(missedInjMchirp):
+      ax.scatter(missedInjMchirp, missedInjDist,c="k", marker='x', edgecolors='k')
+    if len(gIFARMchirp):
+      cb = ax.figure.colorbar(p)
+      cb.ax.set_ylabel("FAP")
+    ax.grid()
+    ax.set_xlabel("Mchirp")
+    ax.set_ylabel("Distance (Mpc)")
+    ax.set_title("Injections found louder than loudest background event")
+    fig.savefig("%s/missed_found_injections_dist.png" % outdir)
+    plt.close()
+
+    fig = plt.figure()
+    ax = fig.gca(yscale="log")
     if len(missedInjTime):
       ax.scatter(missedInjTime, missedInjDist, c="k", marker='x', edgecolors='k')
     if len(gMissed2Time):
       ax.scatter(gMissed2Time, gMissed2Dist, c="r", marker='x',\
                   edgecolors='r')
-    if len(gFoundTime):
-      ax.scatter(gFoundTime, gFoundDist, c="b", marker='x', edgecolors='g')
-    ax.grid()
     if len(gIFARTime):
       p = ax.scatter(gIFARTime, gIFARDist, c=gIFARStat,\
                     norm=colors.Normalize(0,1,clip=False),\
                     marker='o', edgecolors='none')
-    ax.set_yscale("log")
+    if len(gFoundTime):
+      ax.scatter(gFoundTime, gFoundDist, c="b", marker='x', edgecolors='b')
     if len(gIFARTime):
       cb = ax.figure.colorbar(p)
       cb.ax.set_ylabel("FAP")
+    ax.grid()
     ax.set_xlabel("Time since %d" % grbTime)
     ax.set_ylabel("Distance (Mpc)")
     ax.set_title("Injections found louder than loudest background event")
     ax.set_xlim([ start, end ])
     fig.savefig("%s/found_missed_injections_dist_time.png" % outdir)
+    plt.close()
+
+    fig = plt.figure()
+    ax = fig.gca(yscale="log")
+    if len(gFoundTime):
+      ax.scatter(gFoundTime, gFoundDist, c="b", marker='x', edgecolors='b')
+    if len(gIFARTime):
+      p = ax.scatter(gIFARTime, gIFARDist, c=gIFARStat,\
+                    norm=colors.Normalize(0,1,clip=False),\
+                    marker='o', edgecolors='none')
+    if len(gMissed2Time):
+      ax.scatter(gMissed2Time, gMissed2Dist, c="r", marker='x',\
+                  edgecolors='r')
+    if len(missedInjTime):
+      ax.scatter(missedInjTime, missedInjDist, c="k", marker='x', edgecolors='k')
+    if len(gIFARTime):
+      cb = ax.figure.colorbar(p)
+      cb.ax.set_ylabel("FAP")
+    ax.grid()
+    ax.set_xlabel("Time since %d" % grbTime)
+    ax.set_ylabel("Distance (Mpc)")
+    ax.set_title("Injections found louder than loudest background event")
+    ax.set_xlim([ start, end ])
+    fig.savefig("%s/missed_found_injections_dist_time.png" % outdir)
     plt.close()
 
     # plot sky recovery

--- a/bin/pylal_cbc_cohptf_efficiency
+++ b/bin/pylal_cbc_cohptf_efficiency
@@ -38,7 +38,7 @@ import os,sys,matplotlib,numpy as np,re,copy,optparse
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 from matplotlib import rc,cm,colors
-rc("image", cmap="cividis")
+rc("image", cmap="cividis_r")
 from pylal import SimInspiralUtils,MultiInspiralUtils,plotutils,git_version
 from glue import segments,markup
 from pylal.dq import dqSegmentUtils,dqHTMLUtils
@@ -1359,7 +1359,9 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
   # ==========
   # make plots
   # ==========
-#  makePaperPlots()
+
+  # define the 'found' injection colour
+  fnd_col = cm.get_cmap()(0)
 
   # plot cumulative histograms
   for i,bin in enumerate(massBins):
@@ -1581,104 +1583,292 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
     plt.close()
 
     # plot found/missed injections
+    # found missed effective distance v chirp mass
     fig = plt.figure()
     ax = fig.gca(yscale="log")
     if len(missedInjMchirp):
-      ax.scatter(missedInjMchirp, missedInjEffDist, c="k", marker='x',\
-                 edgecolors='k')
+      ax.scatter(missedInjMchirp, missedInjEffDist, c="k", marker="x", s=10)
     if len(gMissed2Mchirp):
-      ax.scatter(gMissed2Mchirp, gMissed2EffDist, c="r", marker='x',\
-                 edgecolors='r')
+      ax.scatter(gMissed2Mchirp, gMissed2EffDist, c="r", marker="x", s=10)
     if len(gIFARMchirp):
-      p = ax.scatter(gIFARMchirp, gIFAREffDist, c=gIFARStat,\
-                     norm=colors.Normalize(0,1,clip=False), marker='o',\
-                     edgecolors='none')
+      p = ax.scatter(gIFARMchirp, gIFAREffDist, c=gIFARStat, vmin=0, vmax=1,
+                     s=40, edgecolor="w")
     if len(gFoundMchirp):
-      ax.scatter(gFoundMchirp, gFoundEffDist, c="b", marker='x',\
-                 edgecolors='b')
-    ax.grid()
+      ax.scatter(gFoundMchirp, gFoundEffDist, c=fnd_col, marker="+", s=30)
     if len(gIFARMchirp):
       cb = plt.colorbar(p, label="FAP")
-    ax.set_xlabel("Mchirp")
-    ax.set_ylabel("Inverse sum of effective distances")
-    ax.set_title("Injections found louder than loudest background event")
+    ax.grid()
+    ax.set_xlabel("Chirp Mass (solar masses)")
+    ax.set_ylabel("Inverse sum of effective distances (Mpc)")
+    ax.set_title("Injection recovery vs background")
+    plt.tight_layout()
     fig.savefig('%s/found_missed_injections_effdist.png' % outdir)
     plt.close()
 
+    # missed found effective distance v chirp mass
     fig = plt.figure()
     ax = fig.gca(yscale="log")
     if len(gFoundMchirp):
-      ax.scatter(gFoundMchirp, gFoundEffDist, c="b", marker='x',\
-                 edgecolors='b')
+      ax.scatter(gFoundMchirp, gFoundEffDist, c=fnd_col, marker="+", s=15)
     if len(gIFARMchirp):
-      p = ax.scatter(gIFARMchirp, gIFAREffDist, c=gIFARStat,\
-                     norm=colors.Normalize(0,1,clip=False), marker='o',\
-                     edgecolors='none')
+      p = ax.scatter(gIFARMchirp, gIFAREffDist, c=gIFARStat, vmin=0, vmax=1,
+                     s=30, edgecolor="w")
     if len(gMissed2Mchirp):
-      ax.scatter(gMissed2Mchirp, gMissed2EffDist, c="r", marker='x',\
-                 edgecolors='r')
+      ax.scatter(gMissed2Mchirp, gMissed2EffDist, c="r", marker="x", s=40)
     if len(missedInjMchirp):
-      ax.scatter(missedInjMchirp, missedInjEffDist, c="k", marker='x',\
-                 edgecolors='k')
-    ax.grid()
+      ax.scatter(missedInjMchirp, missedInjEffDist, c="k", marker="x", s=40)
     if len(gIFARMchirp):
-      cb = ax.figure.colorbar(p)
-      cb.ax.set_ylabel("FAP")
-    ax.set_xlabel("Mchirp")
-    ax.set_ylabel("Inverse sum of effective distances")
-    ax.set_title("Injections found louder than loudest background event")
+      cb = plt.colorbar(p, label="FAP")
+    ax.grid()
+    ax.set_xlabel("Chirp Mass (solar masses)")
+    ax.set_ylabel("Inverse sum of effective distances (Mpc)")
+    ax.set_title("Injection recovery vs background")
+    plt.tight_layout()
     fig.savefig('%s/missed_found_injections_effdist.png' % outdir)
     plt.close()
 
+    # found missed effective distance v time
     fig = plt.figure()
     ax = fig.gca(yscale="log")
     if len(missedInjTime):
-      ax.scatter(missedInjTime, missedInjEffDist, c="k", marker='x',\
-                 edgecolors='k')
+      ax.scatter(missedInjTime, missedInjEffDist, c="k", marker='x', s=10)
     if len(gMissed2Time):
-      ax.scatter(gMissed2Time, gMissed2EffDist, c="r", marker='x',\
-                 edgecolors='r')
+      ax.scatter(gMissed2Time, gMissed2EffDist, c="r", marker='x', s=10)
     if len(gIFARTime):
-      p = ax.scatter(gIFARTime, gIFAREffDist, c=gIFARStat,\
-                     norm=colors.Normalize(0,1,clip=False), marker='o',\
-                     edgecolors='none')
+      p = ax.scatter(gIFARTime, gIFAREffDist, c=gIFARStat, vmin=0, vmax=1,
+                     s=40, edgecolor="w")
     if len(gFoundTime):
-      ax.scatter(gFoundTime, gFoundEffDist, c="b", marker='x', edgecolors='b')
-    ax.grid()
+      ax.scatter(gFoundTime, gFoundEffDist, c=fnd_col, marker='+', s=30)
     if len(gIFARTime):
-      cb = ax.figure.colorbar(p)
-      cb.ax.set_ylabel("FAP")
+      cb = plt.colorbar(p, label="FAP")
+    ax.grid()
     ax.set_xlabel("Time since %d" % grbTime)
-    ax.set_ylabel("Inverse sum of effective distances")
-    ax.set_title("Injections found louder than loudest background event")
-    ax.set_xlim([ start, end ])
+    ax.set_ylabel("Inverse sum of effective distances (Mpc)")
+    ax.set_title("Injection recovery vs background")
+    ax.set_xlim(start, end)
+    plt.tight_layout()
     fig.savefig("%s/found_missed_injections_effdist_time.png" % outdir)
     plt.close()
 
+    # missed found effective distance v time
     fig = plt.figure()
     ax = fig.gca(yscale="log")
     if len(gFoundTime):
-      ax.scatter(gFoundTime, gFoundEffDist, c="b", marker='x', edgecolors='b')
+      ax.scatter(gFoundTime, gFoundEffDist, c=fnd_col, marker='+', s=15)
     if len(gIFARTime):
-      p = ax.scatter(gIFARTime, gIFAREffDist, c=gIFARStat,\
-                     norm=colors.Normalize(0,1,clip=False), marker='o',\
-                     edgecolors='none')
+      p = ax.scatter(gIFARTime, gIFAREffDist, c=gIFARStat, vmin=0, vmax=1,
+                     s=30, edgecolor="w")
     if len(gMissed2Time):
-      ax.scatter(gMissed2Time, gMissed2EffDist, c="r", marker='x',\
-                 edgecolors='r')
+      ax.scatter(gMissed2Time, gMissed2EffDist, c="r", marker='x', s=40)
     if len(missedInjTime):
-      ax.scatter(missedInjTime, missedInjEffDist, c="k", marker='x',\
-                 edgecolors='k')
-    ax.grid()
+      ax.scatter(missedInjTime, missedInjEffDist, c="k", marker='x', s=40)
     if len(gIFARTime):
-      cb = ax.figure.colorbar(p)
-      cb.ax.set_ylabel("FAP")
+      cb = plt.colorbar(p, label="FAP")
+    ax.grid()
     ax.set_xlabel("Time since %d" % grbTime)
-    ax.set_ylabel("Inverse sum of effective distances")
-    ax.set_title("Injections found louder than loudest background event")
-    ax.set_xlim([ start, end ])
+    ax.set_ylabel("Inverse sum of effective distances (Mpc)")
+    ax.set_title("Injection recovery vs background")
+    ax.set_xlim(start, end)
+    plt.tight_layout()
     fig.savefig("%s/missed_found_injections_effdist_time.png" % outdir)
     plt.close()
+
+    # found missed distance v chirp mass
+    fig = plt.figure()
+    ax = fig.gca(yscale="log")
+    if len(missedInjMchirp):
+      ax.scatter(missedInjMchirp, missedInjDist, c="k", marker="x", s=10)
+    if len(gMissed2Mchirp):
+      ax.scatter(gMissed2Mchirp, gMissed2Dist, c="r", marker="x", s=10)
+    if len(gIFARMchirp):
+      p = ax.scatter(gIFARMchirp, gIFARDist, c=gIFARStat, vmin=0, vmax=1,
+                     s=40, edgecolor="w")
+    if len(gFoundMchirp):
+      ax.scatter(gFoundMchirp, gFoundDist, c=fnd_col, marker="+", s=30)
+    if len(gIFARMchirp):
+      cb = plt.colorbar(p, label="FAP")
+    ax.grid()
+    ax.set_xlabel("Chirp Mass (solar masses)")
+    ax.set_ylabel("Distance (Mpc)")
+    ax.set_title("Injection recovery vs background")
+    plt.tight_layout()
+    fig.savefig("%s/found_missed_injections_dist.png" % outdir)
+    plt.close()
+
+    # missed found distance v chirp mass
+    fig = plt.figure()
+    ax = fig.gca(yscale="log")
+    if len(gFoundMchirp):
+      ax.scatter(gFoundMchirp, gFoundDist, c=fnd_col, marker="+", s=15)
+    if len(gIFARMchirp):
+      p = ax.scatter(gIFARMchirp, gIFARDist, c=gIFARStat, vmin=0, vmax=1,
+                     s=30, edgecolor="w")
+    if len(gMissed2Mchirp):
+      ax.scatter(gMissed2Mchirp, gMissed2Dist, c="r", marker="x", s=40)
+    if len(missedInjMchirp):
+      ax.scatter(missedInjMchirp, missedInjDist, c="k", marker="x", s=40)
+    if len(gIFARMchirp):
+      cb = plt.colorbar(p, label="FAP")
+    ax.grid()
+    ax.set_xlabel("Chirp Mass (solar masses)")
+    ax.set_ylabel("Distance (Mpc)")
+    ax.set_title("Injection recovery vs background")
+    plt.tight_layout()
+    fig.savefig("%s/missed_found_injections_dist.png" % outdir)
+    plt.close()
+
+    # found missed distance v time
+    fig = plt.figure()
+    ax = fig.gca(yscale="log")
+    if len(missedInjTime):
+      ax.scatter(missedInjTime, missedInjDist, c="k", marker='x', s=10)
+    if len(gMissed2Time):
+      ax.scatter(gMissed2Time, gMissed2Dist, c="r", marker='x', s=10)
+    if len(gIFARTime):
+      p = ax.scatter(gIFARTime, gIFARDist, c=gIFARStat, vmin=0, vmax=1,
+                     s=40, edgecolor="w")
+    if len(gFoundTime):
+      ax.scatter(gFoundTime, gFoundDist, c=fnd_col, marker='+', s=30)
+    if len(gIFARTime):
+      cb = plt.colorbar(p, label="FAP")
+    ax.grid()
+    ax.set_xlabel("Time since %d" % grbTime)
+    ax.set_ylabel("Distance (Mpc)")
+    ax.set_title("Injection recovery vs background")
+    ax.set_xlim(start, end)
+    plt.tight_layout()
+    fig.savefig("%s/found_missed_injections_dist_time.png" % outdir)
+    plt.close()
+
+    # missed found distance v time
+    fig = plt.figure()
+    ax = fig.gca(yscale="log")
+    if len(gFoundTime):
+      ax.scatter(gFoundTime, gFoundDist, c=fnd_col, marker='+', s=15)
+    if len(gIFARTime):
+      p = ax.scatter(gIFARTime, gIFARDist, c=gIFARStat, vmin=0, vmax=1,
+                     s=30, edgecolor="w")
+    if len(gMissed2Time):
+      ax.scatter(gMissed2Time, gMissed2Dist, c="r", marker='x', s=40)
+    if len(missedInjTime):
+      ax.scatter(missedInjTime, missedInjDist, c="k", marker='x', s=40)
+    if len(gIFARTime):
+      cb = plt.colorbar(p, label="FAP")
+    ax.grid()
+    ax.set_xlabel("Time since %d" % grbTime)
+    ax.set_ylabel("Distance (Mpc)")
+    ax.set_title("Injection recovery vs background")
+    ax.set_xlim(start, end)
+    plt.tight_layout()
+    fig.savefig("%s/missed_found_injections_dist_time.png" % outdir)
+    plt.close()
+
+    # Site-specific plots
+    sitename = { 'G':'GEO', 'H':'Hanford', 'L':'Livingston', 'V':'Virgo',\
+                 'T':'TAMA' }
+
+    for site in sites:
+      fig = plt.figure()
+      ax = fig.gca(yscale="log")
+      if len(missedInjMchirp):
+        ax.scatter(missedInjMchirp, missedInjEffSiteDist[site], c="k", s=10,
+                   marker="x")
+      if len(gMissed2Mchirp):
+        ax.scatter(gMissed2Mchirp, gMissed2EffSiteDist[site], c="r", s=10,
+                   marker="x")
+      if len(gIFARMchirp):
+        p = ax.scatter(gIFARMchirp, gIFAREffSiteDist[site], c=gIFARStat, s=40,
+                       vmin=0, vmax=1, edgecolor="w")
+      if len(gFoundMchirp):
+        ax.scatter(gFoundMchirp, gFoundEffSiteDist[site], c=fnd_col, s=30,
+                   marker="+")
+      if len(gIFARMchirp):
+        cb = plt.colorbar(p, label="FAP")
+      ax.grid()
+      ax.set_xlabel("Chirp Mass (solar masses)")
+      ax.set_ylabel("%s effective distance (Mpc)" % sitename[site])
+      ax.set_title("Injection recovery vs background")
+      plt.tight_layout()
+      fig.savefig("%s/found_missed_injections_effdist_%s.png"\
+                   % (outdir, site.lower()))
+      plt.close()
+
+      fig = plt.figure()
+      ax = fig.gca(yscale="log")
+      if len(gFoundMchirp):
+        ax.scatter(gFoundMchirp, gFoundEffSiteDist[site], c=fnd_col, s=15,
+                   marker="+")
+      if len(gIFARMchirp):
+        p = ax.scatter(gIFARMchirp, gIFAREffSiteDist[site], c=gIFARStat, s=30,
+                       vmin=0, vmax=1, edgecolor="w")
+      if len(gMissed2Mchirp):
+        ax.scatter(gMissed2Mchirp, gMissed2EffSiteDist[site], c="r", s=40,
+                   marker="x")
+      if len(missedInjMchirp):
+        ax.scatter(missedInjMchirp, missedInjEffSiteDist[site], c="k", s=40,
+                   marker="x")
+      if len(gIFARMchirp):
+        cb = plt.colorbar(p, label="FAP")
+      ax.grid()
+      ax.set_xlabel("Chirp Mass (solar masses)")
+      ax.set_ylabel("%s effective distance (Mpc)" % sitename[site])
+      ax.set_title("Injection recovery vs background")
+      plt.tight_layout()
+      fig.savefig("%s/missed_found_injections_effdist_%s.png"\
+                   % (outdir, site.lower()))
+      plt.close()
+
+      fig = plt.figure()
+      ax = fig.gca(yscale="log")
+      if len(missedInjTime):
+        ax.scatter(missedInjTime, missedInjEffSiteDist[site], c="k", s=10,
+                   marker="x")
+      if len(gMissed2Time):
+        ax.scatter(gMissed2Time, gMissed2EffSiteDist[site], c="r", s=10,
+                   marker="x")
+      if len(gIFARTime):
+        p = ax.scatter(gIFARTime, gIFAREffSiteDist[site], c=gIFARStat, s=40,
+                       vmin=0, vmax=1, edgecolor="w")
+      if len(gFoundTime):
+        ax.scatter(gFoundTime, gFoundEffSiteDist[site], c=fnd_col, s=30,
+                   marker="+")
+      if len(gIFARTime):
+        cb = plt.colorbar(p, label="FAP")
+      ax.grid()
+      ax.set_xlabel("Time since %d" % grbTime)
+      ax.set_ylabel("%s effective distance (Mpc)" % sitename[site])
+      ax.set_title("Injection recovery vs background")
+      ax.set_xlim(start, end)
+      plt.tight_layout()
+      fig.savefig("%s/found_missed_injections_effdist_time_%s.png"\
+                   % (outdir, site.lower()))
+      plt.close()
+
+      fig = plt.figure()
+      ax = fig.gca(yscale="log")
+      if len(gFoundTime):
+        ax.scatter(gFoundTime, gFoundEffSiteDist[site], c=fnd_col, s=15,
+                   marker="+")
+      if len(gIFARTime):
+        p = ax.scatter(gIFARTime, gIFAREffSiteDist[site], c=gIFARStat, s=30,
+                       vmin=0, vmax=1, edgecolor="w")
+      if len(gMissed2Time):
+        ax.scatter(gMissed2Time, gMissed2EffSiteDist[site], c="r", s=40,
+                   marker="x")
+      if len(missedInjTime):
+        ax.scatter(missedInjTime, missedInjEffSiteDist[site], c="k", s=40,
+                   marker="x")
+      if len(gIFARTime):
+        cb = plt.colorbar(p, label="FAP")
+      ax.grid()
+      ax.set_xlabel("Time since %d" % grbTime)
+      ax.set_ylabel("%s effective distance (Mpc)" % sitename[site])
+      ax.set_title("Injection recovery vs background")
+      ax.set_xlim(start, end)
+      plt.tight_layout()
+      fig.savefig("%s/missed_found_injections_effdist_time_%s.png"\
+                   % (outdir, site.lower()))
+      plt.close()
 
     # Injections vs. spins plot
     fig = plt.figure()
@@ -1712,8 +1902,7 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
       ax.scatter(gFoundSpin1, gFoundSpin2, c="g", marker="x",
                  edgecolors="g")
     if len(gIFARSpin1x):
-      cb = ax.figure.colorbar(p)
-      cb.ax.set_ylabel("FAP")
+      cb = plt.colorbar(p, label="FAP")
     ax.set_xlabel("Spin on 1st binary component")
     ax.set_ylabel("Spin on 2nd binary component")
     ax.set_title("Injection recovery with respect to component spins")
@@ -1738,8 +1927,7 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
     if len(gFoundm1):
       ax.scatter(gFoundm1, gFoundm2, c="b", marker="x", edgecolors="b")
     if len(gIFARm1):
-      cb = ax.figure.colorbar(p)
-      cb.ax.set_ylabel("FAP")
+      cb = plt.colorbar(p, label="FAP")
     ax.set_xlabel("Mass of 1st binary component")
     ax.set_ylabel("Mass of 2nd binary component")
     ax.set_title("Injection recovery with respect to component masses")
@@ -1749,6 +1937,13 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
                  np.ceil(10 * max(maxMissedInjm2, foundInjm2.max())) / 10])
     fig.savefig("%s/found_missed_injections_masses.png" % outdir)
     plt.close()
+
+    # Write inclination recovery to file
+    np.savetxt("%s/found_inclinations.txt" % outdir, np.c_[gFoundTime + grbTime,
+                                                           gFoundInc])
+    np.savetxt("%s/total_inclinations.txt" % outdir,
+               np.c_[np.concatenate((foundInjTime, missedInjTime)),
+                     np.concatenate((foundInjInc, missedInjInc))])
 
     # Injections vs. inclinations plot
     fig = plt.figure()
@@ -1766,224 +1961,11 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
     if len(gFoundInc):
       ax.scatter(gFoundMchirp, gFoundInc, c="b", marker="x", edgecolors="b")
     if len(gIFARInc):
-      cb = ax.figure.colorbar(p)
-      cb.ax.set_ylabel("FAP")
+      cb = plt.colorbar(p, label="FAP")
     ax.set_xlabel("Mchirp")
     ax.set_ylabel("Inclination angle of binary")
     ax.set_title("Injection recovery with respect to inclination angle")
     fig.savefig("%s/found_missed_injections_incs.png" % outdir)
-    plt.close()
-
-    # Write inclination recovery to file
-    np.savetxt("%s/found_inclinations.txt" % outdir, np.c_[gFoundTime + grbTime,
-                                                           gFoundInc])
-    np.savetxt("%s/total_inclinations.txt" % outdir,
-               np.c_[np.concatenate((foundInjTime, missedInjTime)),
-                     np.concatenate((foundInjInc, missedInjInc))])
-
-    # Site-specific plots
-    sitename = { 'G':'GEO', 'H':'Hanford', 'L':'Livingston', 'V':'Virgo',\
-                 'T':'TAMA' }
-
-    for site in sites:
-      fig = plt.figure()
-      ax = fig.gca(yscale="log")
-      if len(missedInjMchirp):
-        ax.scatter(missedInjMchirp, missedInjEffSiteDist[site],\
-                   c="k", marker='x', edgecolors='k')
-      if len(gMissed2Mchirp):
-        ax.scatter(gMissed2Mchirp, gMissed2EffSiteDist[site],\
-                  c="r", marker='x', edgecolors='r')
-      if len(gIFARMchirp):
-        p = ax.scatter(gIFARMchirp, gIFAREffSiteDist[site],\
-                      c=gIFARStat, norm=colors.Normalize(0,1,clip=False),\
-                      marker='o', edgecolors='none')
-      if len(gFoundMchirp):
-        ax.scatter(gFoundMchirp, gFoundEffSiteDist[site],\
-                  c="b", marker='x', edgecolors='b')
-      if len(gIFARMchirp):
-        cb = ax.figure.colorbar(p)
-        cb.ax.set_ylabel("FAP")
-      ax.grid()
-      ax.set_xlabel("Mchirp")
-      ax.set_ylabel("%s effective distance" % sitename[site])
-      ax.set_title("Injections found louder than loudest background event")
-      fig.savefig("%s/found_missed_injections_effdist_%s.png"\
-                   % (outdir, site.lower()))
-      plt.close()
-
-      fig = plt.figure()
-      ax = fig.gca(yscale="log")
-      if len(gFoundMchirp):
-        ax.scatter(gFoundMchirp, gFoundEffSiteDist[site],\
-                  c="b", marker='x', edgecolors='b')
-      if len(gIFARMchirp):
-        p = ax.scatter(gIFARMchirp, gIFAREffSiteDist[site],\
-                      c=gIFARStat, norm=colors.Normalize(0,1,clip=False),\
-                      marker='o', edgecolors='none')
-      if len(gMissed2Mchirp):
-        ax.scatter(gMissed2Mchirp, gMissed2EffSiteDist[site],\
-                  c="r", marker='x', edgecolors='r')
-      if len(missedInjMchirp):
-        ax.scatter(missedInjMchirp, missedInjEffSiteDist[site],\
-                   c="k", marker='x', edgecolors='k')
-      if len(gIFARMchirp):
-        cb = ax.figure.colorbar(p)
-        cb.ax.set_ylabel("FAP")
-      ax.grid()
-      ax.set_xlabel("Mchirp")
-      ax.set_ylabel("%s effective distance" % sitename[site])
-      ax.set_title("Injections found louder than loudest background event")
-      fig.savefig("%s/missed_found_injections_effdist_%s.png"\
-                   % (outdir, site.lower()))
-      plt.close()
-
-      fig = plt.figure()
-      ax = fig.gca(yscale="log")
-      if len(missedInjTime):
-        ax.scatter(missedInjTime, missedInjEffSiteDist[site],\
-                  c="k", marker='x', edgecolors='k')
-      if len(gMissed2Time):
-        ax.scatter(gMissed2Time, gMissed2EffSiteDist[site],\
-                  c="r", marker='x', edgecolors='r')
-      if len(gIFARTime):
-        p = ax.scatter(gIFARTime ,gIFAREffSiteDist[site],\
-                      c=gIFARStat, norm=colors.Normalize(0,1,clip=False),\
-                      marker='o', edgecolors='none')
-      if len(gFoundTime):
-        ax.scatter(gFoundTime, gFoundEffSiteDist[site],\
-                  c="b", marker='x', edgecolors='b')
-      if len(gIFARTime):
-        cb = ax.figure.colorbar(p)
-        cb.ax.set_ylabel("FAP")
-      ax.grid()
-      ax.set_xlabel("Time since %d" % grbTime)
-      ax.set_ylabel("%s effective distance" % sitename[site])
-      ax.set_title("Injections found louder than loudest background event")
-      ax.set_xlim([ start, end ])
-      fig.savefig("%s/found_missed_injections_effdist_time_%s.png"\
-                   % (outdir, site.lower()))
-      plt.close()
-
-      fig = plt.figure()
-      ax = fig.gca(yscale="log")
-      if len(gFoundTime):
-        ax.scatter(gFoundTime, gFoundEffSiteDist[site],\
-                  c="b", marker='x', edgecolors='b')
-      if len(gIFARTime):
-        p = ax.scatter(gIFARTime ,gIFAREffSiteDist[site],\
-                      c=gIFARStat, norm=colors.Normalize(0,1,clip=False),\
-                      marker='o', edgecolors='none')
-      if len(gMissed2Time):
-        ax.scatter(gMissed2Time, gMissed2EffSiteDist[site],\
-                  c="r", marker='x', edgecolors='r')
-      if len(missedInjTime):
-        ax.scatter(missedInjTime, missedInjEffSiteDist[site],\
-                  c="k", marker='x', edgecolors='k')
-      if len(gIFARTime):
-        cb = ax.figure.colorbar(p)
-        cb.ax.set_ylabel("FAP")
-      ax.grid()
-      ax.set_xlabel("Time since %d" % grbTime)
-      ax.set_ylabel("%s effective distance" % sitename[site])
-      ax.set_title("Injections found louder than loudest background event")
-      ax.set_xlim([ start, end ])
-      fig.savefig("%s/missed_found_injections_effdist_time_%s.png"\
-                   % (outdir, site.lower()))
-      plt.close()
-
-    fig = plt.figure()
-    ax = fig.gca(yscale="log")
-    if len(missedInjMchirp):
-      ax.scatter(missedInjMchirp, missedInjDist,c="k", marker='x', edgecolors='k')
-    if len(gMissed2Mchirp):
-      ax.scatter(gMissed2Mchirp, gMissed2Dist,c="r", marker='x',\
-                  edgecolors='r')
-    if len(gIFARMchirp):
-      p = ax.scatter(gIFARMchirp, gIFARDist, c=gIFARStat,\
-                    norm=colors.Normalize(0,1,clip=False),\
-                    marker='o', edgecolors='none')
-    if len(gFoundMchirp):
-      ax.scatter(gFoundMchirp, gFoundDist, c="b", marker='x', edgecolors='b')
-    if len(gIFARMchirp):
-      cb = ax.figure.colorbar(p)
-      cb.ax.set_ylabel("FAP")
-    ax.grid()
-    ax.set_xlabel("Mchirp")
-    ax.set_ylabel("Distance (Mpc)")
-    ax.set_title("Injections found louder than loudest background event")
-    fig.savefig("%s/found_missed_injections_dist.png" % outdir)
-    plt.close()
-
-    fig = plt.figure()
-    ax = fig.gca(yscale="log")
-    if len(gFoundMchirp):
-      ax.scatter(gFoundMchirp, gFoundDist, c="b", marker='x', edgecolors='b')
-    if len(gIFARMchirp):
-      p = ax.scatter(gIFARMchirp, gIFARDist, c=gIFARStat,\
-                    norm=colors.Normalize(0,1,clip=False),\
-                    marker='o', edgecolors='none')
-    if len(gMissed2Mchirp):
-      ax.scatter(gMissed2Mchirp, gMissed2Dist,c="r", marker='x',\
-                  edgecolors='r')
-    if len(missedInjMchirp):
-      ax.scatter(missedInjMchirp, missedInjDist,c="k", marker='x', edgecolors='k')
-    if len(gIFARMchirp):
-      cb = ax.figure.colorbar(p)
-      cb.ax.set_ylabel("FAP")
-    ax.grid()
-    ax.set_xlabel("Mchirp")
-    ax.set_ylabel("Distance (Mpc)")
-    ax.set_title("Injections found louder than loudest background event")
-    fig.savefig("%s/missed_found_injections_dist.png" % outdir)
-    plt.close()
-
-    fig = plt.figure()
-    ax = fig.gca(yscale="log")
-    if len(missedInjTime):
-      ax.scatter(missedInjTime, missedInjDist, c="k", marker='x', edgecolors='k')
-    if len(gMissed2Time):
-      ax.scatter(gMissed2Time, gMissed2Dist, c="r", marker='x',\
-                  edgecolors='r')
-    if len(gIFARTime):
-      p = ax.scatter(gIFARTime, gIFARDist, c=gIFARStat,\
-                    norm=colors.Normalize(0,1,clip=False),\
-                    marker='o', edgecolors='none')
-    if len(gFoundTime):
-      ax.scatter(gFoundTime, gFoundDist, c="b", marker='x', edgecolors='b')
-    if len(gIFARTime):
-      cb = ax.figure.colorbar(p)
-      cb.ax.set_ylabel("FAP")
-    ax.grid()
-    ax.set_xlabel("Time since %d" % grbTime)
-    ax.set_ylabel("Distance (Mpc)")
-    ax.set_title("Injections found louder than loudest background event")
-    ax.set_xlim([ start, end ])
-    fig.savefig("%s/found_missed_injections_dist_time.png" % outdir)
-    plt.close()
-
-    fig = plt.figure()
-    ax = fig.gca(yscale="log")
-    if len(gFoundTime):
-      ax.scatter(gFoundTime, gFoundDist, c="b", marker='x', edgecolors='b')
-    if len(gIFARTime):
-      p = ax.scatter(gIFARTime, gIFARDist, c=gIFARStat,\
-                    norm=colors.Normalize(0,1,clip=False),\
-                    marker='o', edgecolors='none')
-    if len(gMissed2Time):
-      ax.scatter(gMissed2Time, gMissed2Dist, c="r", marker='x',\
-                  edgecolors='r')
-    if len(missedInjTime):
-      ax.scatter(missedInjTime, missedInjDist, c="k", marker='x', edgecolors='k')
-    if len(gIFARTime):
-      cb = ax.figure.colorbar(p)
-      cb.ax.set_ylabel("FAP")
-    ax.grid()
-    ax.set_xlabel("Time since %d" % grbTime)
-    ax.set_ylabel("Distance (Mpc)")
-    ax.set_title("Injections found louder than loudest background event")
-    ax.set_xlim([ start, end ])
-    fig.savefig("%s/missed_found_injections_dist_time.png" % outdir)
     plt.close()
 
     # plot sky recovery

--- a/bin/pylal_cbc_cohptf_efficiency
+++ b/bin/pylal_cbc_cohptf_efficiency
@@ -778,6 +778,7 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
 
     missedInjs = SimInspiralUtils.ReadSimInspiralFromFiles([missedFile])\
             .veto(vetoes.union(vetoes.keys()))
+    maxinc = float(os.path.basename(missedFile).split("-")[1].split("_")[-2])
 
     foundInjsNoVeto  = SimInspiralUtils.ReadSimInspiralFromFiles([foundFile])
     foundTrigsNVeto = MultiInspiralUtils.ReadMultiInspiralFromFiles([foundFile])
@@ -1612,7 +1613,7 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
       ax.scatter(gFoundMchirp, gFoundEffDist, c=fnd_col, marker="+", s=15)
     if len(gIFARMchirp):
       p = ax.scatter(gIFARMchirp, gIFAREffDist, c=gIFARStat, vmin=0, vmax=1,
-                     s=30, edgecolor="w")
+                     s=40, edgecolor="w")
     if len(gMissed2Mchirp):
       ax.scatter(gMissed2Mchirp, gMissed2EffDist, c="r", marker="x", s=40)
     if len(missedInjMchirp):
@@ -1657,7 +1658,7 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
       ax.scatter(gFoundTime, gFoundEffDist, c=fnd_col, marker='+', s=15)
     if len(gIFARTime):
       p = ax.scatter(gIFARTime, gIFAREffDist, c=gIFARStat, vmin=0, vmax=1,
-                     s=30, edgecolor="w")
+                     s=40, edgecolor="w")
     if len(gMissed2Time):
       ax.scatter(gMissed2Time, gMissed2EffDist, c="r", marker='x', s=40)
     if len(missedInjTime):
@@ -1702,7 +1703,7 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
       ax.scatter(gFoundMchirp, gFoundDist, c=fnd_col, marker="+", s=15)
     if len(gIFARMchirp):
       p = ax.scatter(gIFARMchirp, gIFARDist, c=gIFARStat, vmin=0, vmax=1,
-                     s=30, edgecolor="w")
+                     s=40, edgecolor="w")
     if len(gMissed2Mchirp):
       ax.scatter(gMissed2Mchirp, gMissed2Dist, c="r", marker="x", s=40)
     if len(missedInjMchirp):
@@ -1747,7 +1748,7 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
       ax.scatter(gFoundTime, gFoundDist, c=fnd_col, marker='+', s=15)
     if len(gIFARTime):
       p = ax.scatter(gIFARTime, gIFARDist, c=gIFARStat, vmin=0, vmax=1,
-                     s=30, edgecolor="w")
+                     s=40, edgecolor="w")
     if len(gMissed2Time):
       ax.scatter(gMissed2Time, gMissed2Dist, c="r", marker='x', s=40)
     if len(missedInjTime):
@@ -1799,7 +1800,7 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
         ax.scatter(gFoundMchirp, gFoundEffSiteDist[site], c=fnd_col, s=15,
                    marker="+")
       if len(gIFARMchirp):
-        p = ax.scatter(gIFARMchirp, gIFAREffSiteDist[site], c=gIFARStat, s=30,
+        p = ax.scatter(gIFARMchirp, gIFAREffSiteDist[site], c=gIFARStat, s=40,
                        vmin=0, vmax=1, edgecolor="w")
       if len(gMissed2Mchirp):
         ax.scatter(gMissed2Mchirp, gMissed2EffSiteDist[site], c="r", s=40,
@@ -1850,7 +1851,7 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
         ax.scatter(gFoundTime, gFoundEffSiteDist[site], c=fnd_col, s=15,
                    marker="+")
       if len(gIFARTime):
-        p = ax.scatter(gIFARTime, gIFAREffSiteDist[site], c=gIFARStat, s=30,
+        p = ax.scatter(gIFARTime, gIFAREffSiteDist[site], c=gIFARStat, s=40,
                        vmin=0, vmax=1, edgecolor="w")
       if len(gMissed2Time):
         ax.scatter(gMissed2Time, gMissed2EffSiteDist[site], c="r", s=40,
@@ -1873,36 +1874,32 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
     # Injections vs. spins plot
     fig = plt.figure()
     ax = fig.gca()
-    ax.grid()
     foundInjSpin1 = np.sqrt(foundInjSpin1x**2 + foundInjSpin1y**2 + \
                             foundInjSpin1z**2)
     foundInjSpin2 = np.sqrt(foundInjSpin2x**2 + foundInjSpin2y**2 + \
                             foundInjSpin2z**2)
-    if len(missedInjSpin1x):
-      ax.scatter(missedInjSpin1, missedInjSpin2, c="k", marker="x",
-                 edgecolors="k")
-    if len(gMissed2Spin1x):
-      gMissed2Spin1 = np.sqrt(gMissed2Spin1x**2 + gMissed2Spin1y**2 + \
-                              gMissed2Spin1z**2)
-      gMissed2Spin2 = np.sqrt(gMissed2Spin2x**2 + gMissed2Spin2y**2 + \
-                              gMissed2Spin2z**2)
-      ax.scatter(gMissed2Spin1, gMissed2Spin2, c="r", marker="x",
-                 edgecolors="r")
-    if len(gIFARSpin1x):
-      gIFARSpin1 = np.sqrt(gIFARSpin1x**2 + gIFARSpin1y**2 + gIFARSpin1z**2)
-      gIFARSpin2 = np.sqrt(gIFARSpin2x**2 + gIFARSpin2y**2 + gIFARSpin2z**2)
-      p = ax.scatter(gIFARSpin1, gIFARSpin2, c=gIFARStat,
-                     norm=colors.Normalize(0, 1, clip=False), marker="o",
-                     edgecolors="none")
     if len(gFoundSpin1x):
       gFoundSpin1 = np.sqrt(gFoundSpin1x**2 + gFoundSpin1y**2 + \
                             gFoundSpin1z**2)
       gFoundSpin2 = np.sqrt(gFoundSpin2x**2 + gFoundSpin2y**2 + \
                             gFoundSpin2z**2)
-      ax.scatter(gFoundSpin1, gFoundSpin2, c="g", marker="x",
-                 edgecolors="g")
+      ax.scatter(gFoundSpin1, gFoundSpin2, c=fnd_col, s=15, marker="+")
+    if len(gIFARSpin1x):
+      gIFARSpin1 = np.sqrt(gIFARSpin1x**2 + gIFARSpin1y**2 + gIFARSpin1z**2)
+      gIFARSpin2 = np.sqrt(gIFARSpin2x**2 + gIFARSpin2y**2 + gIFARSpin2z**2)
+      p = ax.scatter(gIFARSpin1, gIFARSpin2, c=gIFARStat, s=40, vmin=0, vmax=1,
+                     edgecolor="w")
+    if len(gMissed2Spin1x):
+      gMissed2Spin1 = np.sqrt(gMissed2Spin1x**2 + gMissed2Spin1y**2 + \
+                              gMissed2Spin1z**2)
+      gMissed2Spin2 = np.sqrt(gMissed2Spin2x**2 + gMissed2Spin2y**2 + \
+                              gMissed2Spin2z**2)
+      ax.scatter(gMissed2Spin1, gMissed2Spin2, c="r", s=40, marker="x")
+    if len(missedInjSpin1x):
+      ax.scatter(missedInjSpin1, missedInjSpin2, c="k", s=40, marker="x")
     if len(gIFARSpin1x):
       cb = plt.colorbar(p, label="FAP")
+    ax.grid()
     ax.set_xlabel("Spin on 1st binary component")
     ax.set_ylabel("Spin on 2nd binary component")
     ax.set_title("Injection recovery with respect to component spins")
@@ -1910,32 +1907,43 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
                                      foundInjSpin1.max())) / 10])
     ax.set_ylim([0, np.ceil(10 * max(maxMissedInjSpin2,
                                      foundInjSpin2.max())) / 10])
-    fig.savefig("%s/found_missed_injections_spins.png" % outdir)
+    plt.tight_layout()
+    fig.savefig("%s/missed_found_injections_spins.png" % outdir)
     plt.close()
 
     # Injections vs. masses plot
+    gFoundq = gFoundm2 / gFoundm1
+    gFoundq = np.where(gFoundq > 1, 1. / gFoundq, gFoundq)
+    gFoundM = gFoundm1 + gFoundm2
+    gIFARq = gIFARm2 / gIFARm1
+    gIFARq = np.where(gIFARq > 1, 1. / gIFARq, gIFARq)
+    gIFARM = gIFARm1 + gIFARm2
+    gMissed2q = gMissed2m2 / gMissed2m1
+    gMissed2q = np.where(gMissed2q > 1, 1. / gMissed2q, gMissed2q)
+    gMissed2M = gMissed2m1 + gMissed2m2
+    missedInjq = missedInjm2 / missedInjm1
+    missedInjq = np.where(missedInjq > 1, 1. / missedInjq, missedInjq)
+    missedInjM = missedInjm1 + missedInjm2
+
     fig = plt.figure()
     ax = fig.gca()
-    ax.grid()
-    if len(missedInjm1):
-      ax.scatter(missedInjm1, missedInjm2, c="k", marker="x", edgecolors="k")
-    if len(gMissed2m1):
-      ax.scatter(gMissed2m1, gMissed2m2, c="r", marker="x", edgecolors="r")
-    if len(gIFARm1):
-      p = ax.scatter(gIFARm1, gIFARm2, c=gIFARStat, edgecolors="none",
-                     norm=colors.Normalize(0, 1, clip=False), marker="o")
     if len(gFoundm1):
-      ax.scatter(gFoundm1, gFoundm2, c="b", marker="x", edgecolors="b")
+      ax.scatter(gFoundq, gFoundM, c=fnd_col, s=15, marker="+")
+    if len(gIFARm1):
+      p = ax.scatter(gIFARq, gIFARM, c=gIFARStat, s=40, vmin=0, vmax=1,
+                     edgecolor="w")
+    if len(gMissed2m1):
+      ax.scatter(gMissed2q, gMissed2M, c="r", s=40, marker="x")
+    if len(missedInjm1):
+      ax.scatter(missedInjq, missedInjM, c="k", s=40, marker="x")
     if len(gIFARm1):
       cb = plt.colorbar(p, label="FAP")
-    ax.set_xlabel("Mass of 1st binary component")
-    ax.set_ylabel("Mass of 2nd binary component")
+    ax.grid()
+    ax.set_xlabel("Mass ratio q")
+    ax.set_ylabel("Total mass M (solar masses)")
     ax.set_title("Injection recovery with respect to component masses")
-    ax.set_xlim([np.floor(10 * min(minMissedInjm1, foundInjm1.min())) / 10,
-                 np.ceil(10 * max(maxMissedInjm1, foundInjm1.max())) / 10])
-    ax.set_ylim([np.floor(10 * max(minMissedInjm2, foundInjm2.min())) / 10,
-                 np.ceil(10 * max(maxMissedInjm2, foundInjm2.max())) / 10])
-    fig.savefig("%s/found_missed_injections_masses.png" % outdir)
+    plt.tight_layout()
+    fig.savefig("%s/missed_found_injections_masses.png" % outdir)
     plt.close()
 
     # Write inclination recovery to file
@@ -1946,26 +1954,61 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
                      np.concatenate((foundInjInc, missedInjInc))])
 
     # Injections vs. inclinations plot
+    gFoundInc2 = 0.5 * np.pi - abs(gFoundInc - 0.5 * np.pi)
+    gIFARInc2 = 0.5 * np.pi - abs(gIFARInc - 0.5 * np.pi)
+    gMissed2Inc2 = 0.5 * np.pi - abs(gMissed2Inc - 0.5 * np.pi)
+    missedInjInc2 = 0.5 * np.pi - abs(missedInjInc - 0.5 * np.pi)
+
     fig = plt.figure()
     ax = fig.gca()
-    ax.grid()
-    if len(missedInjInc):
-      ax.scatter(missedInjMchirp, missedInjInc, c="k", marker="x",
-                 edgecolors="k")
-    if len(gMissed2Inc):
-      ax.scatter(gMissed2Mchirp, gMissed2Inc, c="r", marker="x",
-                 edgecolors="r")
-    if len(gIFARInc):
-      p = ax.scatter(gIFARMchirp, gIFARInc, c=gIFARStat, edgecolors="none",
-                     norm=colors.Normalize(0, 1, clip=False), marker="o")
     if len(gFoundInc):
-      ax.scatter(gFoundMchirp, gFoundInc, c="b", marker="x", edgecolors="b")
+      ax.scatter(np.rad2deg(gFoundInc2), gFoundMchirp, c=fnd_col, s=15,
+                 marker="+")
+    if len(gIFARInc):
+      p = ax.scatter(np.rad2deg(gIFARInc2), gIFARMchirp, c=gIFARStat, s=40,
+                     vmin=0, vmax=1, edgecolor="w")
+    if len(gMissed2Inc):
+      ax.scatter(np.rad2deg(gMissed2Inc2), gMissed2Mchirp, c="r", s=40,
+                 marker="x")
+    if len(missedInjInc):
+      ax.scatter(np.rad2deg(missedInjInc2), missedInjMchirp, c="k", s=40,
+                 marker="x")
     if len(gIFARInc):
       cb = plt.colorbar(p, label="FAP")
-    ax.set_xlabel("Mchirp")
-    ax.set_ylabel("Inclination angle of binary")
+    ax.grid()
+    ax.set_xlabel("Magnitude of inclination | iota |")
+    ax.set_ylabel("Chirp Mass (solar masses)")
     ax.set_title("Injection recovery with respect to inclination angle")
-    fig.savefig("%s/found_missed_injections_incs.png" % outdir)
+    ax.set_xlim(0, maxinc)
+    plt.tight_layout()
+    fig.savefig("%s/missed_found_injections_inc.png" % outdir)
+    plt.close()
+
+    fig = plt.figure()
+    ax = fig.gca(yscale="log")
+    if len(gFoundInc):
+      ax.scatter(np.cos(gFoundInc2), gFoundDist, c=fnd_col, s=15, marker="+")
+    if len(gIFARInc):
+      p = ax.scatter(np.cos(gIFARInc2), gIFARDist, c=gIFARStat, s=40, vmin=0,
+                     vmax=1, edgecolor="w")
+    if len(gMissed2Inc):
+      ax.scatter(np.cos(gMissed2Inc2), gMissed2Dist, c="r", s=40, marker="x")
+    if len(missedInjInc):
+      ax.scatter(np.cos(missedInjInc2), missedInjDist, c="k", s=40, marker="x")
+    if len(gIFARInc):
+      cb = plt.colorbar(p, label="FAP")
+    tt = np.arange(0, maxinc + 10, 10)
+    tks = np.cos(np.deg2rad(tt))
+    tk_labs = [u'cos(%d\xb0)' % tk for tk in tt]
+    plt.xticks(tks, tk_labs, fontsize=10)
+    fig.autofmt_xdate()
+    ax.set_xlim(np.cos(np.deg2rad(maxinc)), 1)
+    ax.grid()
+    ax.set_xlabel("cos(|iota|)")
+    ax.set_ylabel("Distance (Mpc)")
+    ax.set_title("Injection recovery with respect to inclination angle")
+    plt.tight_layout()
+    fig.savefig("%s/missed_found_injections_inc_dist.png" % outdir)
     plt.close()
 
     # plot sky recovery
@@ -1989,7 +2032,7 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
 #    if gIFARMchirp:
 #      ax.plot(gIFARMchirp, gIFARSkyAngle, 'b.')
     ax.grid()
-    ax.set_xlabel("Mchirp")
+    ax.set_xlabel("Chirp Mass (solar masses)")
     ax.set_ylabel("Rec. sky error (radians)")
     fig.savefig('%s/found_sky_error_mchirp.png' % outdir)
     plt.close()

--- a/bin/pylal_cbc_cohptf_efficiency
+++ b/bin/pylal_cbc_cohptf_efficiency
@@ -38,6 +38,7 @@ import os,sys,matplotlib,numpy as np,re,copy,optparse
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 from matplotlib import rc,cm,colors
+rc("image", cmap="cividis")
 from pylal import SimInspiralUtils,MultiInspiralUtils,plotutils,git_version
 from glue import segments,markup
 from pylal.dq import dqSegmentUtils,dqHTMLUtils
@@ -1588,7 +1589,7 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
     if len(gIFARMchirp):
       p = ax.scatter(gIFARMchirp, gIFAREffDist, c=gIFARStat,\
                      norm=colors.Normalize(0,1,clip=False), marker='o',\
-                     edgecolors='none', cmap=cm.plasma)
+                     edgecolors='none')
     if len(gMissed2Mchirp):
       ax.scatter(gMissed2Mchirp, gMissed2EffDist, c="r", marker='x',\
                  edgecolors='r')
@@ -1618,7 +1619,7 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
     if len(gIFARMchirp):
       p = ax.scatter(gIFARMchirp, gIFAREffDist, c=gIFARStat,\
                      norm=colors.Normalize(0,1,clip=False), marker='o',\
-                     edgecolors='none', cmap=cm.plasma)
+                     edgecolors='none')
     if len(gFoundMchirp):
       ax.scatter(gFoundMchirp, gFoundEffDist, c="b", marker='x',\
                  edgecolors='g')
@@ -1641,7 +1642,7 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
     if len(gIFARTime):
       p = ax.scatter(gIFARTime, gIFAREffDist, c=gIFARStat,\
                      norm=colors.Normalize(0,1,clip=False), marker='o',\
-                     edgecolors='none', cmap=cm.plasma)
+                     edgecolors='none')
     if len(gMissed2Time):
       ax.scatter(gMissed2Time, gMissed2EffDist, c="r", marker='x',\
                  edgecolors='r')
@@ -1672,7 +1673,7 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
     if len(gIFARTime):
       p = ax.scatter(gIFARTime, gIFAREffDist, c=gIFARStat,\
                      norm=colors.Normalize(0,1,clip=False), marker='o',\
-                     edgecolors='none', cmap=cm.plasma)
+                     edgecolors='none')
     if len(gFoundTime):
       ax.scatter(gFoundTime, gFoundEffDist, c="b", marker='x', edgecolors='g')
     ax.grid()
@@ -1708,7 +1709,7 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
       gIFARSpin2 = np.sqrt(gIFARSpin2x**2 + gIFARSpin2y**2 + gIFARSpin2z**2)
       p = ax.scatter(gIFARSpin1, gIFARSpin2, c=gIFARStat,
                      norm=colors.Normalize(0, 1, clip=False), marker="o",
-                     edgecolors="none", cmap=cm.plasma)
+                     edgecolors="none")
     if len(missedInjSpin1x):
       ax.scatter(missedInjSpin1, missedInjSpin2, c="k", marker="x",
                  edgecolors="k")
@@ -1740,8 +1741,7 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
       ax.scatter(gFoundm1, gFoundm2, c="g", marker="x", edgecolors="g")
     if len(gIFARm1):
       p = ax.scatter(gIFARm1, gIFARm2, c=gIFARStat, edgecolors="none",
-                     norm=colors.Normalize(0, 1, clip=False), marker="o",
-                     cmap=cm.plasma)
+                     norm=colors.Normalize(0, 1, clip=False), marker="o")
     if len(missedInjm1):
       ax.scatter(missedInjm1, missedInjm2, c="k", marker="x", edgecolors="k")
     if len(gMissed2m1):
@@ -1767,8 +1767,7 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
       ax.scatter(gFoundMchirp, gFoundInc, c="g", marker="x", edgecolors="g")
     if len(gIFARInc):
       p = ax.scatter(gIFARMchirp, gIFARInc, c=gIFARStat, edgecolors="none",
-                     norm=colors.Normalize(0, 1, clip=False), marker="o",
-                     cmap=cm.plasma)
+                     norm=colors.Normalize(0, 1, clip=False), marker="o")
     if len(gMissed2Inc):
       ax.scatter(gMissed2Mchirp, gMissed2Inc, c="r", marker="x",
                  edgecolors="r")
@@ -1811,7 +1810,7 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
       if len(gIFARMchirp):
         p = ax.scatter(gIFARMchirp, gIFAREffSiteDist[site],\
                       c=gIFARStat, norm=colors.Normalize(0,1,clip=False),\
-                      marker='o', edgecolors='none', cmap=cm.plasma)
+                      marker='o', edgecolors='none')
       ax.semilogy()
       if len(gIFARMchirp):
         cb = ax.figure.colorbar(p)
@@ -1839,7 +1838,7 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
       if len(gIFARTime):
         p = ax.scatter(gIFARTime ,gIFAREffSiteDist[site],\
                       c=gIFARStat, norm=colors.Normalize(0,1,clip=False),\
-                      marker='o', edgecolors='none', cmap=cm.plasma)
+                      marker='o', edgecolors='none')
       ax.semilogy()
       if len(gIFARTime):
         cb = ax.figure.colorbar(p)
@@ -1866,7 +1865,7 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
     if len(gIFARMchirp):
       p = ax.scatter(gIFARMchirp, gIFARDist, c=gIFARStat,\
                     norm=colors.Normalize(0,1,clip=False),\
-                    marker='o', edgecolors='none', cmap=cm.plasma)
+                    marker='o', edgecolors='none')
     ax.semilogy()
     if len(gIFARMchirp):
       cb = ax.figure.colorbar(p)
@@ -1891,7 +1890,7 @@ def main(segdir, outdir, trigFile, foundFile, missedFile,\
     if len(gIFARTime):
       p = ax.scatter(gIFARTime, gIFARDist, c=gIFARStat,\
                     norm=colors.Normalize(0,1,clip=False),\
-                    marker='o', edgecolors='none', cmap=cm.plasma)
+                    marker='o', edgecolors='none')
     ax.semilogy()
     if len(gIFARTime):
       cb = ax.figure.colorbar(p)

--- a/bin/pylal_cbc_cohptf_sbv_plotter
+++ b/bin/pylal_cbc_cohptf_sbv_plotter
@@ -31,6 +31,7 @@ import os,matplotlib,copy
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 from matplotlib import rc
+rc("image", cmap="cividis")
 from math import sqrt
 import scipy.stats
 from optparse import OptionParser


### PR DESCRIPTION
There have been a few plotting bugs in need of squashing.

- [x] Make the colormap used for FAP colour scale colour-blind friendly and uniform perception. The colormap to use here appears to be [`cividis`.](https://matplotlib.org/3.2.1/users/prev_whats_new/whats_new_2.2.html#cividis-colormap)
- [x] Attempt to fix the odd y-axis scaling that sometimes happens in injection plots.
- [x] Duplicate injection plots but with one version having missed injections at front, another with found at front
- [x] Ensure plot titles fit in figure bounds
- [x] Consider changing marker size in injection recovery plots for easier consumption