### PR TITLE
Stop sidereal drift from smearing out the grid

### DIFF
--- a/bin/pylal_cbc_cohptf_sbv_plotter
+++ b/bin/pylal_cbc_cohptf_sbv_plotter
@@ -1142,12 +1142,17 @@ def main(trigFile, injFile, tag, outdir, segdir, chisq_index=4.0,\
                      "failed with zeros in a loglog plot\n")
 
   # plot sky grid
+  # remove the sidereal drift from the longitudes and plot points as at GRB time
+  lons = trigLongitude - (numpy.array(trigTime) * 360.0 / 86164.0905)
+  # plot only unique points
+  lats, indices = numpy.unique(trigLatitude, return_index=True)
+
   fig = plt.figure()
   ax  = fig.gca()
-  ax.set_title("coh\_PTF %s Sky Grid" % tag, fontsize=18)
+  ax.set_title("coh_PTF Sky Grid for %s" % tag, fontsize=18)
   ax.set_xlabel("Longitude (Degrees)", fontsize=16)
   ax.set_ylabel("Latitude (Degrees)", fontsize=16)
-  ax.plot(trigLongitude, trigLatitude, 'ko', markerfacecolor='blue')
+  ax.plot(lons[indices], lats, 'ko', markerfacecolor='blue')
   fig.savefig("%s/%s_sky_grid.png" % (outdir, tag))
   plt.close()
   p+=1 

--- a/bin/pylal_cbc_cohptf_sbv_plotter
+++ b/bin/pylal_cbc_cohptf_sbv_plotter
@@ -1169,6 +1169,7 @@ def main(trigFile, injFile, tag, outdir, segdir, chisq_index=4.0,\
                   else type(labels[0])(float(l) + 360) if float(l) < 0
                   else l for l in labels]
     ax.set_xticklabels(new_labels)
+  ax.grid()
   fig.savefig("%s/%s_sky_grid.png" % (outdir, tag))
   plt.close()
   p+=1 

--- a/bin/pylal_cbc_cohptf_sbv_plotter
+++ b/bin/pylal_cbc_cohptf_sbv_plotter
@@ -1162,12 +1162,15 @@ def main(trigFile, injFile, tag, outdir, segdir, chisq_index=4.0,\
   ax.set_title("coh_PTF Sky Grid for %s" % tag, fontsize=18)
   ax.set_xlabel("Longitude (Degrees)", fontsize=16)
   ax.set_ylabel("Latitude (Degrees)", fontsize=16)
-  ax.plot(lons, lats, 'ko', markerfacecolor='blue')
+  ax.plot(360 - lons, lats, 'ko', markerfacecolor='blue')
   if grid_wrap:
     labels = ax.get_xticks().tolist()
-    new_labels = [l - 360 if l >= 360 else l + 360 if l < 0 else l
+    new_labels = [l - 360 if l > 360 else l + 360 if l <= 0 else l
                   for l in labels]
-    ax.set_xticklabels(new_labels)
+  else:
+    new_labels = ax.get_xticks().tolist()
+  new_labels = [360 - l for l in new_labels]
+  ax.set_xticklabels(new_labels)
   ax.grid()
   plt.tight_layout()
   fig.savefig("%s/%s_sky_grid.png" % (outdir, tag))

--- a/bin/pylal_cbc_cohptf_sbv_plotter
+++ b/bin/pylal_cbc_cohptf_sbv_plotter
@@ -1165,12 +1165,31 @@ def main(trigFile, injFile, tag, outdir, segdir, chisq_index=4.0,\
   ax.plot(lons, lats, 'ko', markerfacecolor='blue')
   if grid_wrap:
     labels = ax.get_xticks().tolist()
-    new_labels = [type(labels[0])(float(l) - 360) if float(l) >= 360
-                  else type(labels[0])(float(l) + 360) if float(l) < 0
-                  else l for l in labels]
+    new_labels = [l - 360 if l >= 360 else l + 360 if l < 0 else l
+                  for l in labels]
     ax.set_xticklabels(new_labels)
   ax.grid()
+  plt.tight_layout()
   fig.savefig("%s/%s_sky_grid.png" % (outdir, tag))
+  plt.close()
+  p+=1 
+
+  # plot on full sky
+  mol_lons = numpy.array([l - 360 if l > 180 else l for l in lons], dtype=float)
+  fig = plt.figure()
+  ax  = fig.gca(projection="mollweide")
+  ax.set_title("coh_PTF Sky Grid for %s" % tag, fontsize=18)
+  ax.grid()
+  plt.draw()
+  labels = [l.get_text().encode('ascii','ignore') for l in ax.get_xticklabels()]
+  new_labels = [int(l) + 360 if int(l) <= 0 else int(l) for l in labels]
+  new_labels = [unicode(str(360 - l) + u"\xb0") for l in new_labels]
+  ax.set_xticklabels(new_labels)
+  ax.tick_params(axis='both', which='major', labelsize=10)
+  ax.scatter(-numpy.radians(mol_lons), numpy.radians(lats), c='blue',
+             edgecolors='none', s=3)
+  plt.tight_layout()
+  fig.savefig("%s/%s_sky_grid_mollweide.png" % (outdir, tag))
   plt.close()
   p+=1 
 

--- a/bin/pylal_cbc_cohptf_sbv_plotter
+++ b/bin/pylal_cbc_cohptf_sbv_plotter
@@ -1142,17 +1142,33 @@ def main(trigFile, injFile, tag, outdir, segdir, chisq_index=4.0,\
                      "failed with zeros in a loglog plot\n")
 
   # plot sky grid
-  # remove the sidereal drift from the longitudes and plot points as at GRB time
-  lons = trigLongitude - (numpy.array(trigTime) * 360.0 / 86164.0905)
   # plot only unique points
   lats, indices = numpy.unique(trigLatitude, return_index=True)
+  # remove the sidereal drift from the longitudes and plot points as at GRB time
+  lons = trigLongitude - (numpy.array(trigTime) * 360.0 / 86164.0905)
+  lons = lons[indices]
+
+  # handle grids that cross the meridian better
+  grid_wrap = False
+  if any(lons < 90) and any(lons > 270):
+    grid_wrap = True
+    if lons.mean() < 180:
+      lons = numpy.where(lons > 180, lons - 360, lons)
+    else:
+      lons = numpy.where(lons < 180, lons + 360, lons)
 
   fig = plt.figure()
   ax  = fig.gca()
   ax.set_title("coh_PTF Sky Grid for %s" % tag, fontsize=18)
   ax.set_xlabel("Longitude (Degrees)", fontsize=16)
   ax.set_ylabel("Latitude (Degrees)", fontsize=16)
-  ax.plot(lons[indices], lats, 'ko', markerfacecolor='blue')
+  ax.plot(lons, lats, 'ko', markerfacecolor='blue')
+  if grid_wrap:
+    labels = ax.get_xticks().tolist()
+    new_labels = [type(labels[0])(float(l) - 360) if float(l) > 360
+                  else type(labels[0])(float(l) + 360) if float(l) < 0
+                  else l for l in labels]
+    ax.set_xticklabels(new_labels)
   fig.savefig("%s/%s_sky_grid.png" % (outdir, tag))
   plt.close()
   p+=1 

--- a/bin/pylal_cbc_cohptf_sbv_plotter
+++ b/bin/pylal_cbc_cohptf_sbv_plotter
@@ -1165,7 +1165,7 @@ def main(trigFile, injFile, tag, outdir, segdir, chisq_index=4.0,\
   ax.plot(lons, lats, 'ko', markerfacecolor='blue')
   if grid_wrap:
     labels = ax.get_xticks().tolist()
-    new_labels = [type(labels[0])(float(l) - 360) if float(l) > 360
+    new_labels = [type(labels[0])(float(l) - 360) if float(l) >= 360
                   else type(labels[0])(float(l) + 360) if float(l) < 0
                   else l for l in labels]
     ax.set_xticklabels(new_labels)


### PR DESCRIPTION
This PR is to address some issues raised in #54, specifically:

- [x] Remove the time smearing in the sky grid plot
- [x] Have the sky grid plot wrap correctly, i.e. x-axis should not start/end at 0/360 degrees when a grid crosses the meridian